### PR TITLE
chore(docs): repoint repo references prabod → basecompute

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ and Swift.
 ### 1. Install
 
 ```sh
-curl -LsSf https://raw.githubusercontent.com/prabod/baseRT/main/install.sh | sh
+curl -LsSf https://raw.githubusercontent.com/basecompute/baseRT/main/install.sh | sh
 ```
 
 This downloads the prebuilt engine + the `basert` CLI to `~/.basert` and adds it
@@ -31,7 +31,7 @@ afterward (or `export PATH="$HOME/.basert:$PATH"`).
 
 ```sh
 # Prebuilt engine (libbaseRT.dylib + basert-* tools), into build/
-gh release download --repo prabod/baseRT --pattern 'basert-engine-macos-arm64*.tar.gz'
+gh release download --repo basecompute/baseRT --pattern 'basert-engine-macos-arm64*.tar.gz'
 mkdir -p build && tar -xzf basert-engine-macos-arm64*.tar.gz -C build
 
 # The basert CLI (model hub + converter + launcher) — needs Rust 1.80+

--- a/base-convert/Cargo.toml
+++ b/base-convert/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
-repository = "https://github.com/prabod/baseRT"
+repository = "https://github.com/basecompute/baseRT"
 rust-version = "1.80"
 
 [workspace.dependencies]

--- a/docs/bindings/index.md
+++ b/docs/bindings/index.md
@@ -6,10 +6,10 @@ wrappers for four languages. All of them link the single `libbaseRT.dylib`
 
 | Language | Package | Import | Source |
 | --- | --- | --- | --- |
-| [Python](python.md) | `baseRT` | `import baseRT` | [`bindings/python`](https://github.com/prabod/baseRT/tree/main/bindings/python) |
-| [Node](node.md) | `@baseRT/node` | `import { BaseRTModel }` | [`bindings/node`](https://github.com/prabod/baseRT/tree/main/bindings/node) |
-| [Rust](rust.md) | `baseRT` | `use baseRT::…` | [`bindings/rust`](https://github.com/prabod/baseRT/tree/main/bindings/rust) |
-| [Swift](swift.md) | `BaseRT` | `import BaseRT` | [`bindings/swift`](https://github.com/prabod/baseRT/tree/main/bindings/swift) |
+| [Python](python.md) | `baseRT` | `import baseRT` | [`bindings/python`](https://github.com/basecompute/baseRT/tree/main/bindings/python) |
+| [Node](node.md) | `@baseRT/node` | `import { BaseRTModel }` | [`bindings/node`](https://github.com/basecompute/baseRT/tree/main/bindings/node) |
+| [Rust](rust.md) | `baseRT` | `use baseRT::…` | [`bindings/rust`](https://github.com/basecompute/baseRT/tree/main/bindings/rust) |
+| [Swift](swift.md) | `BaseRT` | `import BaseRT` | [`bindings/swift`](https://github.com/basecompute/baseRT/tree/main/bindings/swift) |
 
 ## Finding the engine
 

--- a/docs/bindings/node.md
+++ b/docs/bindings/node.md
@@ -49,5 +49,5 @@ const model = new BaseRTModel("models/your-model.base");
 // transcription are exposed on the model instance.
 ```
 
-See [`bindings/node`](https://github.com/prabod/baseRT/tree/main/bindings/node)
+See [`bindings/node`](https://github.com/basecompute/baseRT/tree/main/bindings/node)
 for the full API and the struct-ABI tests.

--- a/docs/bindings/python.md
+++ b/docs/bindings/python.md
@@ -61,5 +61,5 @@ m = baseRT.Model("models/whisper-base.base")
 # pass PCM samples / audio per the transcribe() signature
 ```
 
-See [`bindings/python`](https://github.com/prabod/baseRT/tree/main/bindings/python)
+See [`bindings/python`](https://github.com/basecompute/baseRT/tree/main/bindings/python)
 for the full surface and tests.

--- a/docs/bindings/rust.md
+++ b/docs/bindings/rust.md
@@ -48,5 +48,5 @@ let stats = model.generate(&tokens, 256, Default::default(), |_id, text| {
 println!("\n{} tokens", stats.generated_tokens);
 ```
 
-See [`bindings/rust`](https://github.com/prabod/baseRT/tree/main/bindings/rust)
+See [`bindings/rust`](https://github.com/basecompute/baseRT/tree/main/bindings/rust)
 for the full API, the `static` feature, and examples.

--- a/docs/bindings/swift.md
+++ b/docs/bindings/swift.md
@@ -37,5 +37,5 @@ let stats = model.generate(tokens: tokens, maxTokens: 256) { token in
 }
 ```
 
-See [`bindings/swift`](https://github.com/prabod/baseRT/tree/main/bindings/swift)
+See [`bindings/swift`](https://github.com/basecompute/baseRT/tree/main/bindings/swift)
 for the full API.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -3,7 +3,7 @@
 ## One-shot install (recommended)
 
 ```sh
-curl -LsSf https://raw.githubusercontent.com/prabod/baseRT/main/install.sh | sh
+curl -LsSf https://raw.githubusercontent.com/basecompute/baseRT/main/install.sh | sh
 ```
 
 This downloads the prebuilt engine bundle (the `libbaseRT.dylib`, the `basert`
@@ -48,7 +48,7 @@ kernels embedded), the `basert-*` tools, `baseRT.metallib`, and the public
 headers.
 
 ```sh
-gh release download --repo prabod/baseRT --pattern 'basert-engine-macos-arm64*.tar.gz'
+gh release download --repo basecompute/baseRT --pattern 'basert-engine-macos-arm64*.tar.gz'
 mkdir -p build && tar -xzf basert-engine-macos-arm64*.tar.gz -C build
 # build/ now has libbaseRT.dylib + basert-serve, basert-chat, … + baseRT.metallib + include/
 ```

--- a/docs/guides/benchmarking.md
+++ b/docs/guides/benchmarking.md
@@ -23,7 +23,7 @@ The output reports prefill tokens/sec (prompt processing) and decode tokens/sec
 
 ## Reproducible benchmark scripts
 
-The [`benchmarks/`](https://github.com/prabod/baseRT/tree/main/benchmarks)
+The [`benchmarks/`](https://github.com/basecompute/baseRT/tree/main/benchmarks)
 directory has scripts that drive `basert bench` across models and context
 lengths, plus reference results under `benchmarks/results/`. They expect the
 engine bundle unpacked into `build/` (so `build/basert-bench` exists) — see

--- a/docs/reference/base-format.md
+++ b/docs/reference/base-format.md
@@ -12,7 +12,7 @@ You produce `.base` files with [`basert convert`](../guides/converting.md) or
 
 The authoritative container specification lives in the repo:
 
-- **[`base-convert/FORMAT.md`](https://github.com/prabod/baseRT/blob/main/base-convert/FORMAT.md)**
+- **[`base-convert/FORMAT.md`](https://github.com/basecompute/baseRT/blob/main/base-convert/FORMAT.md)**
   — header schema, tensor table, slot layout, and the on-disk byte layout.
 
 ## Inspecting a bundle

--- a/docs/reference/engine-releases.md
+++ b/docs/reference/engine-releases.md
@@ -1,7 +1,7 @@
 # Engine releases
 
 The BaseRT engine is distributed as a prebuilt binary bundle under
-[Releases](https://github.com/prabod/baseRT/releases). This repository — the
+[Releases](https://github.com/basecompute/baseRT/releases). This repository — the
 CLI, format, headers, bindings, and docs — is open source (Apache-2.0); the
 engine is provided as a ready-to-use binary, so you never need to build it from
 source.
@@ -21,7 +21,7 @@ source.
 ## Installing a release
 
 ```sh
-gh release download --repo prabod/baseRT --pattern 'basert-engine-macos-arm64*.tar.gz'
+gh release download --repo basecompute/baseRT --pattern 'basert-engine-macos-arm64*.tar.gz'
 mkdir -p build && tar -xzf basert-engine-macos-arm64*.tar.gz -C build
 export PATH="$PWD/build:$PWD/base-convert/target/release:$PATH"
 ```

--- a/docs/reference/profiles.md
+++ b/docs/reference/profiles.md
@@ -5,9 +5,9 @@ rules. `basert convert --profile <path>` applies it; the bundle records the
 profile name for audit.
 
 The generic profiles ship in
-[`base-convert/profiles/`](https://github.com/prabod/baseRT/tree/main/base-convert/profiles)
+[`base-convert/profiles/`](https://github.com/basecompute/baseRT/tree/main/base-convert/profiles)
 (`default-q4`, `default-q8`, and scale-dtype variants). Full guidance is in
-[`profiles/PROFILES.md`](https://github.com/prabod/baseRT/blob/main/base-convert/profiles/PROFILES.md).
+[`profiles/PROFILES.md`](https://github.com/basecompute/baseRT/blob/main/base-convert/profiles/PROFILES.md).
 
 ## Schema
 

--- a/docs/reference/quantization.md
+++ b/docs/reference/quantization.md
@@ -8,7 +8,7 @@ canonical spec; this page is an overview.
 
 The authoritative quantization specification lives in the repo:
 
-- **[`base-convert/CANONICAL_QUANT_SPEC.md`](https://github.com/prabod/baseRT/blob/main/base-convert/CANONICAL_QUANT_SPEC.md)**
+- **[`base-convert/CANONICAL_QUANT_SPEC.md`](https://github.com/basecompute/baseRT/blob/main/base-convert/CANONICAL_QUANT_SPEC.md)**
   — dtypes, group sizes, scale dtypes, symmetric/asymmetric rules, and the
   per-tensor header fields.
 

--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -1,7 +1,7 @@
 # Security
 
 The full policy — including how to report vulnerabilities privately — is in
-[`SECURITY.md`](https://github.com/prabod/baseRT/blob/main/SECURITY.md) at the
+[`SECURITY.md`](https://github.com/basecompute/baseRT/blob/main/SECURITY.md) at the
 repo root. This page summarizes the operational essentials.
 
 ## Running the server safely
@@ -32,5 +32,5 @@ loadable (by design for development); gate on `verify` in production.
 ## Reporting
 
 Report vulnerabilities privately per
-[`SECURITY.md`](https://github.com/prabod/baseRT/blob/main/SECURITY.md). Please
+[`SECURITY.md`](https://github.com/basecompute/baseRT/blob/main/SECURITY.md). Please
 don't open public issues for security reports.

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # BaseRT one-shot installer.
 #
-#   curl -LsSf https://raw.githubusercontent.com/prabod/baseRT/main/install.sh | sh
+#   curl -LsSf https://raw.githubusercontent.com/basecompute/baseRT/main/install.sh | sh
 #
 # Downloads the latest prebuilt engine bundle (libbaseRT.dylib + the basert CLI
 # and runtime tools) and installs it to ~/.basert, then adds it to your PATH.
@@ -12,7 +12,7 @@
 #   BASERT_NO_MODIFY_PATH  set to 1 to skip editing shell profiles
 set -eu
 
-REPO="prabod/baseRT"
+REPO="basecompute/baseRT"
 ASSET_PREFIX="basert-engine-macos-arm64"
 INSTALL_DIR="${BASERT_INSTALL_DIR:-$HOME/.basert}"
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,8 @@
 site_name: BaseRT
 site_description: A fast LLM inference runtime for Apple Silicon (Metal).
-site_url: https://prabod.github.io/baseRT/
-repo_url: https://github.com/prabod/baseRT
-repo_name: prabod/baseRT
+site_url: https://basecompute.github.io/baseRT/
+repo_url: https://github.com/basecompute/baseRT
+repo_name: basecompute/baseRT
 edit_uri: edit/main/docs/
 
 theme:


### PR DESCRIPTION
Repoints every `prabod/baseRT` reference in the public mirror to `basecompute/baseRT`, fixing the broken installer and docs after the org move.

## Fixes
- **install.sh** — `REPO="basecompute/baseRT"` + curl URL (the one-shot installer pulled releases from the old org).
- **mkdocs.yml** — `site_url` → `basecompute.github.io/baseRT`, `repo_url`/`repo_name` → basecompute (broken doc-site header links + edit URIs).
- **README.md** — install one-liner + `gh release download --repo` target.
- **docs/** — ~13 source/blob/tree links across getting-started, bindings, reference, guides.
- **base-convert/Cargo.toml** — `repository` metadata.

## Follow-up (separate from this PR)
GitHub Pages is not yet enabled on this repo — the docs site won't publish until Settings → Pages → Source = GitHub Actions is turned on.