### PR TITLE
sync: bring base-convert source current with internal engine

### DIFF
--- a/base-convert/crates/base-arch/src/bert.rs
+++ b/base-convert/crates/base-arch/src/bert.rs
@@ -152,8 +152,8 @@ impl GgufMapper for NomicBertMapper {
                 let rest = n.strip_prefix("blk.")?;
                 let (layer_str, suffix) = rest.split_once('.')?;
                 let layer: u32 = layer_str.parse().ok()?;
-                // BERT-specific suffixes keep their GGUF name; the
-                // runtime's BERT loader queries the same names
+                // BERT-specific suffixes keep their GGUF name; runtime
+                // (src/core/models/bert.cpp) queries the same names
                 // verbatim with a `layers.N.` prefix.
                 let canonical = match suffix {
                     "attn_qkv.weight" => "self_attn.qkv_proj.weight",

--- a/base-convert/crates/base-arch/src/lib.rs
+++ b/base-convert/crates/base-arch/src/lib.rs
@@ -76,6 +76,24 @@ pub fn hf_mapper_for_model_type(model_type: &str) -> Option<&'static dyn HfMappe
     }
 }
 
+/// Every HF `model_type` value [`hf_mapper_for_model_type`] accepts. Kept in
+/// lockstep with that match so a pre-flight support check (and its error
+/// message) has a single source of truth for what convert-on-pull supports.
+pub const SUPPORTED_HF_MODEL_TYPES: &[&str] = &[
+    "llama",
+    "qwen2",
+    "qwen3",
+    "qwen2_moe",
+    "qwen3_moe",
+    "nomic_bert",
+    "gemma",
+    "gemma2",
+    "gemma3",
+    "gemma3_text",
+    "gemma4",
+    "gemma4_text",
+];
+
 pub trait GgufMapper: Sync {
     /// Canonical arch name stored in the `.base` header's `arch` field.
     fn canonical_arch(&self) -> &'static str;
@@ -278,5 +296,23 @@ impl ArchConfig {
             m.insert("rope_local_theta".into(), json!(self.rope_local_theta));
         }
         m
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `SUPPORTED_HF_MODEL_TYPES` must list exactly what the dispatch match
+    /// accepts — every advertised type resolves, and nothing else creeps in.
+    #[test]
+    fn supported_list_matches_dispatch() {
+        for mt in SUPPORTED_HF_MODEL_TYPES {
+            assert!(
+                hf_mapper_for_model_type(mt).is_some(),
+                "advertised model_type {mt:?} has no mapper"
+            );
+        }
+        assert!(hf_mapper_for_model_type("not-a-real-arch").is_none());
     }
 }

--- a/base-convert/crates/base-convert/src/hub.rs
+++ b/base-convert/crates/base-convert/src/hub.rs
@@ -323,6 +323,36 @@ fn choose_profile(
     Ok((target_str(args.target).to_string(), None, None))
 }
 
+/// Read `model_type` from a fetched `config.json` and fail early when no
+/// converter supports it — so an unsupported repo errors before its weights
+/// are downloaded. `text_config.model_type` is consulted as a fallback for
+/// multimodal configs that nest the language-model arch there.
+fn check_supported_arch(config_path: &Path, repo: &str, revision: &str) -> Result<()> {
+    let bytes = std::fs::read(config_path)
+        .with_context(|| format!("reading {}", config_path.display()))?;
+    let cfg: serde_json::Value = serde_json::from_slice(&bytes)
+        .with_context(|| format!("parsing {} as JSON", config_path.display()))?;
+
+    let model_type = cfg
+        .get("model_type")
+        .and_then(|v| v.as_str())
+        .or_else(|| cfg.pointer("/text_config/model_type").and_then(|v| v.as_str()))
+        .ok_or_else(|| {
+            anyhow::anyhow!("{repo}@{revision}: config.json has no model_type field")
+        })?;
+
+    if base_arch::hf_mapper_for_model_type(model_type).is_some() {
+        return Ok(());
+    }
+
+    bail!(
+        "{repo}@{revision}: model_type {model_type:?} is not supported by convert-on-pull.\n\
+         Supported architectures: {}.\n\
+         Pre-converted models are available via `basert list --remote`.",
+        base_arch::SUPPORTED_HF_MODEL_TYPES.join(", ")
+    )
+}
+
 /// Download the wanted source files into hf-hub's snapshot dir and return it.
 fn download_source(repo: &str, revision: &str, fetcher: &dyn Fetcher) -> Result<PathBuf> {
     let files = fetcher.list_files(repo, revision)?;
@@ -338,6 +368,10 @@ fn download_source(repo: &str, revision: &str, fetcher: &dyn Fetcher) -> Result<
 
     // Anchor the snapshot dir on config.json, then fetch the rest beside it.
     let cfg = fetcher.get_file(repo, revision, "config.json")?;
+    // Pre-flight: reject unsupported architectures from config.json alone,
+    // before downloading multi-GB safetensors. Mirrors the model_type read
+    // in `convert_hf` so the gate matches the eventual conversion.
+    check_supported_arch(&cfg, repo, revision)?;
     let snapshot = cfg
         .parent()
         .map(|p| p.to_path_buf())
@@ -484,18 +518,39 @@ mod tests {
         // Lay out a fake HF repo: <root>/org/model/<files>.
         let repo_dir = tmp.path().join("org").join("model");
         std::fs::create_dir_all(&repo_dir).unwrap();
-        for f in [
-            "config.json",
-            "model.safetensors",
-            "tokenizer.json",
-            "pytorch_model.bin",
-        ] {
+        std::fs::write(repo_dir.join("config.json"), br#"{"model_type":"llama"}"#).unwrap();
+        for f in ["model.safetensors", "tokenizer.json", "pytorch_model.bin"] {
             std::fs::write(repo_dir.join(f), b"x").unwrap();
         }
         let fetcher = MockFetcher::new(tmp.path());
 
         let snapshot = download_source("org/model", "main", &fetcher).unwrap();
         assert_eq!(snapshot, repo_dir);
+    }
+
+    #[test]
+    fn download_source_rejects_unsupported_arch_before_weights() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_dir = tmp.path().join("org").join("exotic");
+        std::fs::create_dir_all(&repo_dir).unwrap();
+        std::fs::write(repo_dir.join("config.json"), br#"{"model_type":"mamba"}"#).unwrap();
+        std::fs::write(repo_dir.join("model.safetensors"), b"x").unwrap();
+        let fetcher = MockFetcher::new(tmp.path());
+
+        let err = download_source("org/exotic", "main", &fetcher).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("mamba"), "{msg}");
+        assert!(msg.contains("not supported"), "{msg}");
+        // The supported set is surfaced so the user knows what works.
+        assert!(msg.contains("llama"), "{msg}");
+    }
+
+    #[test]
+    fn check_supported_arch_reads_nested_text_config() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = tmp.path().join("config.json");
+        std::fs::write(&cfg, br#"{"text_config":{"model_type":"gemma4_text"}}"#).unwrap();
+        check_supported_arch(&cfg, "org/m", "main").unwrap();
     }
 
     #[test]

--- a/base-convert/crates/base-convert/src/main.rs
+++ b/base-convert/crates/base-convert/src/main.rs
@@ -83,7 +83,7 @@ struct ConvertArgs {
     synthetic: bool,
 
     /// Canonical-quant profile JSON (e.g.
-    /// `base-convert/profiles/default-q4.json`). When set,
+    /// `tools/base-convert/profiles/dense-q4mix.json`). When set,
     /// per-tensor quant decisions come from the profile rules; the
     /// `--target` flag becomes the fallback for tensors the profile's
     /// catch-all `**.weight` rule should otherwise have covered. Sets
@@ -1518,8 +1518,8 @@ enum Canonical {
 }
 
 /// nomic-bert HF safetensors → canonical `.base` names. Targets the
-/// same names the GGUF `NomicBertMapper` emits so the runtime's BERT
-/// loader sees one form regardless of source.
+/// same names the GGUF `NomicBertMapper` emits so the runtime
+/// (`src/core/models/bert.cpp`) sees one form regardless of source.
 fn nomic_bert_hf_rename(name: &str) -> Option<String> {
     match name {
         "embeddings.word_embeddings.weight" => return Some("embed_tokens.weight".into()),

--- a/base-convert/crates/base-quant/src/profile.rs
+++ b/base-convert/crates/base-quant/src/profile.rs
@@ -3,7 +3,7 @@
 //! Profiles are reusable JSON configs that name a set of per-tensor
 //! quant rules. The converter takes `--profile <path>` and the
 //! resulting bundle records the profile name in `quant_profile` for
-//! audit. See `base-convert/profiles/*.json`.
+//! audit. See `tools/base-convert/profiles/*.json`.
 //!
 //! Glob syntax (per `CANONICAL_QUANT_SPEC.md`):
 //!   - `*`    matches anything except `.`
@@ -425,7 +425,7 @@ mod tests {
     /// in on-disk profile JSON before they hit the converter.
     #[test]
     fn shipped_default_profiles_parse() {
-        // Profiles live at <repo>/base-convert/profiles/. Walk up
+        // Profiles live at <repo>/tools/base-convert/profiles/. Walk up
         // from CARGO_MANIFEST_DIR (= the base-quant crate) to that path.
         let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap();
         let profiles_dir = std::path::Path::new(&manifest)
@@ -436,10 +436,13 @@ mod tests {
             .join("profiles");
         let names = [
             "default-q4.json",
-            "default-q4-bf16.json",
-            "default-q4-f16scale.json",
             "default-q8.json",
-            "default-q8-f16scale.json",
+            "dense-q4mix.json",
+            "moe-q4mix.json",
+            "q3-aggressive.json",
+            "gemma4-moe-q4mix.json",
+            "gemma4-moe-q4all.json",
+            "gemma4-moe-mlx.json",
         ];
         for name in names {
             let path = profiles_dir.join(name);
@@ -454,6 +457,162 @@ mod tests {
         }
     }
 
+    /// MoE profile must route experts to q4 and shared_ffn / lm_head
+    /// to q8 — the canonical mixed-precision layout.
+    #[test]
+    fn moe_q4mix_profile_routes_correctly() {
+        let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+        let path = std::path::Path::new(&manifest)
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .join("profiles")
+            .join("moe-q4mix.json");
+        let p = QuantProfile::from_path(&path).unwrap();
+
+        // MoE expert: q4 / gs=64.
+        let expert =
+            p.resolve("model.layers.0.mlp.experts.0.gate_proj.weight").unwrap();
+        assert_eq!(expert.dtype, TensorDtype::BaseQ4);
+        assert_eq!(expert.group_size, 64);
+
+        // Shared FFN (Qwen3-MoE / DeepSeek style): q8 / gs=128.
+        let shared = p
+            .resolve("model.layers.0.mlp.shared_experts.gate_proj.weight")
+            .unwrap();
+        assert_eq!(shared.dtype, TensorDtype::BaseQ8);
+        assert_eq!(shared.group_size, 128);
+
+        // lm_head: q8.
+        let lm = p.resolve("lm_head.weight").unwrap();
+        assert_eq!(lm.dtype, TensorDtype::BaseQ8);
+
+        // Router stays in fp (kernel reads f16; profile uses f16
+        // since the runtime's norm/router kernels assume half).
+        let router = p.resolve("model.layers.0.mlp.router.weight").unwrap();
+        assert!(matches!(
+            router.dtype,
+            TensorDtype::F16 | TensorDtype::Bf16
+        ));
+    }
+
+    /// q3-aggressive profile routes MLP / experts to q3 / gs=32 per spec.
+    #[test]
+    fn q3_aggressive_profile_uses_q3_gs32() {
+        let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+        let path = std::path::Path::new(&manifest)
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .join("profiles")
+            .join("q3-aggressive.json");
+        let p = QuantProfile::from_path(&path).unwrap();
+
+        let mlp = p.resolve("model.layers.5.mlp.gate_proj.weight").unwrap();
+        assert_eq!(mlp.dtype, TensorDtype::BaseQ3);
+        assert_eq!(mlp.group_size, 32);
+
+        // Attention stays at q4 even in this profile.
+        let attn = p.resolve("model.layers.5.self_attn.q_proj.weight").unwrap();
+        assert_eq!(attn.dtype, TensorDtype::BaseQ4);
+        assert_eq!(attn.group_size, 64);
+    }
+
+    /// `gemma4-moe-mlx` mirrors `mlx-community/gemma-4-26b-a4b-it-4bit`'s
+    /// per-tensor `quantization` block: q4 default, q8 on the shared-dense
+    /// FFN (`mlp.{gate,up,down}_proj`) and the router projection. Embed
+    /// drops to q4 to match MLX (lm_head is tied; the canonical name
+    /// remap routes through `embed_tokens.weight`). This test pins the
+    /// routing so a future profile edit can't silently drift it.
+    #[test]
+    fn gemma4_moe_mlx_profile_matches_mlx_quant_block() {
+        let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+        let path = std::path::Path::new(&manifest)
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .join("profiles")
+            .join("gemma4-moe-mlx.json");
+        let p = QuantProfile::from_path(&path).unwrap();
+
+        // Shared dense FFN — q8/gs=64 (only path that sees every token
+        // on top of the routed experts; MLX upgrades to 8 bit so q4
+        // residual-stream noise doesn't compound through 30 layers).
+        for proj in ["gate_proj", "up_proj", "down_proj"] {
+            let name = format!("model.layers.0.mlp.{proj}.weight");
+            let r = p.resolve(&name).unwrap_or_else(|| panic!("no rule for {name}"));
+            assert_eq!(r.dtype, TensorDtype::BaseQ8, "mlp.{proj} should be q8");
+            assert_eq!(r.group_size, 64, "mlp.{proj} should be gs=64");
+        }
+
+        // Router projection — q8/gs=64. Picks expert assignments;
+        // q4 noise here silently re-routes to wrong experts which is
+        // unrecoverable, while the bytes saved are negligible.
+        for name in [
+            "model.language_model.layers.0.router.proj.weight",
+            "model.layers.0.mlp.router.weight",
+            "model.layers.0.ffn_gate_inp.weight",
+        ] {
+            let r = p.resolve(name).unwrap_or_else(|| panic!("no rule for {name}"));
+            assert_eq!(r.dtype, TensorDtype::BaseQ8, "{name} should be q8");
+            assert_eq!(r.group_size, 64, "{name} should be gs=64");
+        }
+
+        // Routed experts — q4/gs=64 (the bulk of model bytes; q4 noise
+        // averages across the 8/128 experts that fire per token).
+        for name in [
+            "model.layers.0.experts.gate_up_proj",
+            "model.layers.0.ffn_gate_up_exps.weight",
+            "model.layers.0.ffn_down_exps.weight",
+        ] {
+            let r = p.resolve(name).unwrap_or_else(|| panic!("no rule for {name}"));
+            assert_eq!(r.dtype, TensorDtype::BaseQ4, "{name} should be q4");
+            assert_eq!(r.group_size, 64, "{name} should be gs=64");
+        }
+
+        // Attention projections — q4/gs=64.
+        for proj in ["q_proj", "k_proj", "v_proj", "o_proj"] {
+            let name = format!("model.layers.0.self_attn.{proj}.weight");
+            let r = p.resolve(&name).unwrap_or_else(|| panic!("no rule for {name}"));
+            assert_eq!(r.dtype, TensorDtype::BaseQ4, "self_attn.{proj} should be q4");
+        }
+
+        // Embed_tokens — q4/gs=64 to match MLX (also drops lm_head with
+        // tied embeddings). Saves ~1 GB on 26B-A4B's 262144 vocab vs f16.
+        let embed = p.resolve("model.embed_tokens.weight").unwrap();
+        assert_eq!(embed.dtype, TensorDtype::BaseQ4);
+        assert_eq!(embed.group_size, 64);
+
+        // Norms stay f16 — the runtime's rmsnorm_f16 kernel reads weight
+        // buffers as `half *`, and bf16 norms break that read.
+        for name in [
+            "model.layers.0.input_layernorm.weight",
+            "model.layers.0.post_feedforward_layernorm.weight",
+            "model.layers.0.post_feedforward_layernorm_2.weight",
+            "model.layers.0.post_attention_layernorm.weight",
+            "model.layers.0.pre_feedforward_layernorm.weight",
+            "model.layers.0.pre_feedforward_layernorm_2.weight",
+        ] {
+            let r = p.resolve(name).unwrap_or_else(|| panic!("no rule for {name}"));
+            assert_eq!(r.dtype, TensorDtype::F16, "{name} should be f16");
+        }
+
+        // Per-layer / per-expert scalar weights stay f16 (small, sensitive).
+        for name in [
+            "model.layers.0.layer_scalar",
+            "model.layers.0.layer_out_scale.weight",
+            "model.layers.0.router.per_expert_scale",
+            "model.layers.0.ffn_down_exps.scale",
+            "model.layers.0.router.scale",
+            "model.layers.0.ffn_gate_inp.scale",
+        ] {
+            let r = p.resolve(name).unwrap_or_else(|| panic!("no rule for {name}"));
+            assert_eq!(r.dtype, TensorDtype::F16, "{name} should be f16");
+        }
+    }
 
     #[test]
     fn from_json_roundtrip() {

--- a/base-convert/crates/base-quant/src/profile.rs
+++ b/base-convert/crates/base-quant/src/profile.rs
@@ -3,7 +3,7 @@
 //! Profiles are reusable JSON configs that name a set of per-tensor
 //! quant rules. The converter takes `--profile <path>` and the
 //! resulting bundle records the profile name in `quant_profile` for
-//! audit. See `tools/base-convert/profiles/*.json`.
+//! audit. See `base-convert/profiles/*.json`.
 //!
 //! Glob syntax (per `CANONICAL_QUANT_SPEC.md`):
 //!   - `*`    matches anything except `.`
@@ -425,7 +425,7 @@ mod tests {
     /// in on-disk profile JSON before they hit the converter.
     #[test]
     fn shipped_default_profiles_parse() {
-        // Profiles live at <repo>/tools/base-convert/profiles/. Walk up
+        // Profiles live at <repo>/base-convert/profiles/. Walk up
         // from CARGO_MANIFEST_DIR (= the base-quant crate) to that path.
         let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap();
         let profiles_dir = std::path::Path::new(&manifest)
@@ -436,13 +436,10 @@ mod tests {
             .join("profiles");
         let names = [
             "default-q4.json",
+            "default-q4-bf16.json",
+            "default-q4-f16scale.json",
             "default-q8.json",
-            "dense-q4mix.json",
-            "moe-q4mix.json",
-            "q3-aggressive.json",
-            "gemma4-moe-q4mix.json",
-            "gemma4-moe-q4all.json",
-            "gemma4-moe-mlx.json",
+            "default-q8-f16scale.json",
         ];
         for name in names {
             let path = profiles_dir.join(name);
@@ -457,162 +454,6 @@ mod tests {
         }
     }
 
-    /// MoE profile must route experts to q4 and shared_ffn / lm_head
-    /// to q8 — the canonical mixed-precision layout.
-    #[test]
-    fn moe_q4mix_profile_routes_correctly() {
-        let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap();
-        let path = std::path::Path::new(&manifest)
-            .parent()
-            .unwrap()
-            .parent()
-            .unwrap()
-            .join("profiles")
-            .join("moe-q4mix.json");
-        let p = QuantProfile::from_path(&path).unwrap();
-
-        // MoE expert: q4 / gs=64.
-        let expert =
-            p.resolve("model.layers.0.mlp.experts.0.gate_proj.weight").unwrap();
-        assert_eq!(expert.dtype, TensorDtype::BaseQ4);
-        assert_eq!(expert.group_size, 64);
-
-        // Shared FFN (Qwen3-MoE / DeepSeek style): q8 / gs=128.
-        let shared = p
-            .resolve("model.layers.0.mlp.shared_experts.gate_proj.weight")
-            .unwrap();
-        assert_eq!(shared.dtype, TensorDtype::BaseQ8);
-        assert_eq!(shared.group_size, 128);
-
-        // lm_head: q8.
-        let lm = p.resolve("lm_head.weight").unwrap();
-        assert_eq!(lm.dtype, TensorDtype::BaseQ8);
-
-        // Router stays in fp (kernel reads f16; profile uses f16
-        // since the runtime's norm/router kernels assume half).
-        let router = p.resolve("model.layers.0.mlp.router.weight").unwrap();
-        assert!(matches!(
-            router.dtype,
-            TensorDtype::F16 | TensorDtype::Bf16
-        ));
-    }
-
-    /// q3-aggressive profile routes MLP / experts to q3 / gs=32 per spec.
-    #[test]
-    fn q3_aggressive_profile_uses_q3_gs32() {
-        let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap();
-        let path = std::path::Path::new(&manifest)
-            .parent()
-            .unwrap()
-            .parent()
-            .unwrap()
-            .join("profiles")
-            .join("q3-aggressive.json");
-        let p = QuantProfile::from_path(&path).unwrap();
-
-        let mlp = p.resolve("model.layers.5.mlp.gate_proj.weight").unwrap();
-        assert_eq!(mlp.dtype, TensorDtype::BaseQ3);
-        assert_eq!(mlp.group_size, 32);
-
-        // Attention stays at q4 even in this profile.
-        let attn = p.resolve("model.layers.5.self_attn.q_proj.weight").unwrap();
-        assert_eq!(attn.dtype, TensorDtype::BaseQ4);
-        assert_eq!(attn.group_size, 64);
-    }
-
-    /// `gemma4-moe-mlx` mirrors `mlx-community/gemma-4-26b-a4b-it-4bit`'s
-    /// per-tensor `quantization` block: q4 default, q8 on the shared-dense
-    /// FFN (`mlp.{gate,up,down}_proj`) and the router projection. Embed
-    /// drops to q4 to match MLX (lm_head is tied; the canonical name
-    /// remap routes through `embed_tokens.weight`). This test pins the
-    /// routing so a future profile edit can't silently drift it.
-    #[test]
-    fn gemma4_moe_mlx_profile_matches_mlx_quant_block() {
-        let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap();
-        let path = std::path::Path::new(&manifest)
-            .parent()
-            .unwrap()
-            .parent()
-            .unwrap()
-            .join("profiles")
-            .join("gemma4-moe-mlx.json");
-        let p = QuantProfile::from_path(&path).unwrap();
-
-        // Shared dense FFN — q8/gs=64 (only path that sees every token
-        // on top of the routed experts; MLX upgrades to 8 bit so q4
-        // residual-stream noise doesn't compound through 30 layers).
-        for proj in ["gate_proj", "up_proj", "down_proj"] {
-            let name = format!("model.layers.0.mlp.{proj}.weight");
-            let r = p.resolve(&name).unwrap_or_else(|| panic!("no rule for {name}"));
-            assert_eq!(r.dtype, TensorDtype::BaseQ8, "mlp.{proj} should be q8");
-            assert_eq!(r.group_size, 64, "mlp.{proj} should be gs=64");
-        }
-
-        // Router projection — q8/gs=64. Picks expert assignments;
-        // q4 noise here silently re-routes to wrong experts which is
-        // unrecoverable, while the bytes saved are negligible.
-        for name in [
-            "model.language_model.layers.0.router.proj.weight",
-            "model.layers.0.mlp.router.weight",
-            "model.layers.0.ffn_gate_inp.weight",
-        ] {
-            let r = p.resolve(name).unwrap_or_else(|| panic!("no rule for {name}"));
-            assert_eq!(r.dtype, TensorDtype::BaseQ8, "{name} should be q8");
-            assert_eq!(r.group_size, 64, "{name} should be gs=64");
-        }
-
-        // Routed experts — q4/gs=64 (the bulk of model bytes; q4 noise
-        // averages across the 8/128 experts that fire per token).
-        for name in [
-            "model.layers.0.experts.gate_up_proj",
-            "model.layers.0.ffn_gate_up_exps.weight",
-            "model.layers.0.ffn_down_exps.weight",
-        ] {
-            let r = p.resolve(name).unwrap_or_else(|| panic!("no rule for {name}"));
-            assert_eq!(r.dtype, TensorDtype::BaseQ4, "{name} should be q4");
-            assert_eq!(r.group_size, 64, "{name} should be gs=64");
-        }
-
-        // Attention projections — q4/gs=64.
-        for proj in ["q_proj", "k_proj", "v_proj", "o_proj"] {
-            let name = format!("model.layers.0.self_attn.{proj}.weight");
-            let r = p.resolve(&name).unwrap_or_else(|| panic!("no rule for {name}"));
-            assert_eq!(r.dtype, TensorDtype::BaseQ4, "self_attn.{proj} should be q4");
-        }
-
-        // Embed_tokens — q4/gs=64 to match MLX (also drops lm_head with
-        // tied embeddings). Saves ~1 GB on 26B-A4B's 262144 vocab vs f16.
-        let embed = p.resolve("model.embed_tokens.weight").unwrap();
-        assert_eq!(embed.dtype, TensorDtype::BaseQ4);
-        assert_eq!(embed.group_size, 64);
-
-        // Norms stay f16 — the runtime's rmsnorm_f16 kernel reads weight
-        // buffers as `half *`, and bf16 norms break that read.
-        for name in [
-            "model.layers.0.input_layernorm.weight",
-            "model.layers.0.post_feedforward_layernorm.weight",
-            "model.layers.0.post_feedforward_layernorm_2.weight",
-            "model.layers.0.post_attention_layernorm.weight",
-            "model.layers.0.pre_feedforward_layernorm.weight",
-            "model.layers.0.pre_feedforward_layernorm_2.weight",
-        ] {
-            let r = p.resolve(name).unwrap_or_else(|| panic!("no rule for {name}"));
-            assert_eq!(r.dtype, TensorDtype::F16, "{name} should be f16");
-        }
-
-        // Per-layer / per-expert scalar weights stay f16 (small, sensitive).
-        for name in [
-            "model.layers.0.layer_scalar",
-            "model.layers.0.layer_out_scale.weight",
-            "model.layers.0.router.per_expert_scale",
-            "model.layers.0.ffn_down_exps.scale",
-            "model.layers.0.router.scale",
-            "model.layers.0.ffn_gate_inp.scale",
-        ] {
-            let r = p.resolve(name).unwrap_or_else(|| panic!("no rule for {name}"));
-            assert_eq!(r.dtype, TensorDtype::F16, "{name} should be f16");
-        }
-    }
 
     #[test]
     fn from_json_roundtrip() {


### PR DESCRIPTION
Syncs the open-core `base-convert` CLI source to internal `main`, closing a drift of 5 files the manual sync had missed:

| File | What it brings |
|---|---|
| `base-convert/src/hub.rs` | pull pre-flight architecture support check |
| `base-arch/src/lib.rs` | `SUPPORTED_HF_MODEL_TYPES` |
| `base-quant/src/profile.rs` | profile updates (~169 lines) |
| `base-convert/src/main.rs`, `base-arch/src/bert.rs` | minor updates |

Follow-up: an automated open-core sync workflow (auto-PR on internal `main`) will prevent this drift recurring.