### PR TITLE
ci: fix PR guard so maintainer PRs actually run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,15 +7,17 @@ on:
 
 # Self-hosted runner safety: a push only happens with write access, but a
 # pull_request can come from an external fork. Gate every job so PR runs execute
-# on the laptop runner ONLY for write-access authors (OWNER/MEMBER/COLLABORATOR);
-# fork PRs from outside contributors are skipped (have a maintainer push the
-# branch into the repo, or re-run after review). Also turn on
-# "Require approval for all outside collaborators" in repo Actions settings
-# before making this repo public.
+# on the laptop runner ONLY for branches pushed into THIS repo (i.e. by someone
+# with write access) targeting main/dev; fork PRs have a different
+# head.repo.full_name and are skipped (have a maintainer push the branch into
+# the repo, or re-run after review). The earlier author_association check
+# skipped legitimate maintainer PRs, so this mirrors the engine repo's guard.
+# Also turn on "Require approval for all outside collaborators" in repo Actions
+# settings before making this repo public.
 jobs:
   base-convert:
     name: base-convert (build + test)
-    if: github.event_name != 'pull_request' || contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
+    if: github.event_name == 'push' || (github.event.pull_request.head.repo.full_name == github.repository && (github.base_ref == 'main' || github.base_ref == 'dev'))
     runs-on: [self-hosted, macOS, ARM64, m4pro]
     defaults:
       run:
@@ -28,7 +30,7 @@ jobs:
 
   node-binding:
     name: node binding (build + unit tests)
-    if: github.event_name != 'pull_request' || contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
+    if: github.event_name == 'push' || (github.event.pull_request.head.repo.full_name == github.repository && (github.base_ref == 'main' || github.base_ref == 'dev'))
     runs-on: [self-hosted, macOS, ARM64, m4pro]
     defaults:
       run:
@@ -44,7 +46,7 @@ jobs:
 
   rust-sys-abi:
     name: rust-sys ABI checks
-    if: github.event_name != 'pull_request' || contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
+    if: github.event_name == 'push' || (github.event.pull_request.head.repo.full_name == github.repository && (github.base_ref == 'main' || github.base_ref == 'dev'))
     runs-on: [self-hosted, macOS, ARM64, m4pro]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Problem
The mirror's CI jobs are gated on `author_association ∈ {OWNER,MEMBER,COLLABORATOR}`, but same-repo maintainer PRs (reported as `MEMBER`) were evaluating **false** and skipping — so the repo ran **no PR CI** (only push-to-main ran, masking it). The in-flight base-convert sync PR was never validated as a result.

## Fix
Adopt the engine repo's proven guard:
```
github.event_name == 'push' || (github.event.pull_request.head.repo.full_name == github.repository && base_ref ∈ {main, dev})
```
- Same-repo branches (pushed by someone with write access) → **run**.
- Fork PRs (different `head.repo.full_name`) → **skipped** — stronger self-hosted-runner protection than `author_association`.

This PR's own jobs should now execute (validating the guard).