### PR TITLE
Use basecompute.co/install.sh in install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ and Swift.
 ### 1. Install
 
 ```sh
-curl -LsSf https://raw.githubusercontent.com/basecompute/baseRT/main/install.sh | sh
+curl -LsSf https://basecompute.co/install.sh | sh
 ```
 
 This downloads the prebuilt engine + the `basert` CLI to `~/.basert` and adds it

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -3,7 +3,7 @@
 ## One-shot install (recommended)
 
 ```sh
-curl -LsSf https://raw.githubusercontent.com/basecompute/baseRT/main/install.sh | sh
+curl -LsSf https://basecompute.co/install.sh | sh
 ```
 
 This downloads the prebuilt engine bundle (the `libbaseRT.dylib`, the `basert`

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # BaseRT one-shot installer.
 #
-#   curl -LsSf https://raw.githubusercontent.com/basecompute/baseRT/main/install.sh | sh
+#   curl -LsSf https://basecompute.co/install.sh | sh
 #
 # Downloads the latest prebuilt engine bundle (libbaseRT.dylib + the basert CLI
 # and runtime tools) and installs it to ~/.basert, then adds it to your PATH.


### PR DESCRIPTION
Updates the one-shot installer URL from the GitHub raw link to the hosted **https://basecompute.co/install.sh** (served from the dotcom repo, basecompute/dotcom#1).

Changed in:
- `install.sh` (header comment)
- `README.md`
- `docs/getting-started/installation.md`

The script logic is unchanged; only the advertised command is updated to:

```sh
curl -LsSf https://basecompute.co/install.sh | sh
```