### PR TITLE
feat(hub): pull pre-converted .base directly + populate catalog (17 models) + convert progress

### DIFF
--- a/base-convert/crates/base-convert/src/hub.rs
+++ b/base-convert/crates/base-convert/src/hub.rs
@@ -54,6 +54,64 @@ fn want_source_file(name: &str) -> bool {
         || base.starts_with("tokenizer")
 }
 
+/// Lowercased quant tag — the segment after the last `-`/`_`. Maps a profile
+/// name, `--target` string, or `.base` filename stem to a comparable token:
+/// `default-q4` → `q4`, `base_q8` → `q8`, `Llama-3.2-1B-Instruct-Q4` → `q4`,
+/// `bf16` → `bf16`.
+fn quant_tag(s: &str) -> String {
+    s.rsplit(['-', '_']).next().unwrap_or(s).to_ascii_lowercase()
+}
+
+/// True when `tag` names a quant scheme we know how to label on disk.
+fn is_quant_tag(tag: &str) -> bool {
+    matches!(
+        tag,
+        "q2" | "q3" | "q4" | "q5" | "q6" | "q8" | "bf16" | "mxfp4" | "nvfp4"
+    )
+}
+
+/// The quant the user is asking for, derived from `--profile` (its filename)
+/// or, failing that, `--target`.
+fn quant_token(args: &PullArgs) -> String {
+    if let Some(p) = &args.profile {
+        if let Some(stem) = p.file_stem().and_then(|s| s.to_str()) {
+            return quant_tag(stem);
+        }
+    }
+    quant_tag(target_str(args.target))
+}
+
+/// `path/to/Foo-Q4.base` → `Foo-Q4`.
+fn base_file_stem(f: &str) -> String {
+    let b = f.rsplit('/').next().unwrap_or(f);
+    b.strip_suffix(".base").unwrap_or(b).to_string()
+}
+
+/// List the `.base` artifacts a repo hosts (empty when it ships none).
+fn list_base_files(fetcher: &dyn Fetcher, repo: &str, revision: &str) -> Result<Vec<String>> {
+    let files = fetcher
+        .list_files(repo, revision)
+        .with_context(|| format!("listing files in {repo}@{revision}"))?;
+    Ok(files.into_iter().filter(|f| f.ends_with(".base")).collect())
+}
+
+/// Pick the `.base` whose quant tag matches `want`. Falls back to the sole
+/// artifact when the repo has exactly one; errors when several are present and
+/// none match.
+fn select_base_file<'a>(files: &'a [String], want: &str) -> Result<&'a String> {
+    if let Some(f) = files.iter().find(|f| quant_tag(&base_file_stem(f)) == want) {
+        return Ok(f);
+    }
+    if let [only] = files {
+        return Ok(only);
+    }
+    let avail: Vec<String> = files.iter().map(|f| quant_tag(&base_file_stem(f))).collect();
+    bail!(
+        "no pre-converted .base for quant {want:?} in this repo; it offers: {}",
+        avail.join(", ")
+    )
+}
+
 /// Decide whether `token` should be treated as a hub model id rather than a
 /// filesystem path. Hub ids are HuggingFace-style `namespace/name` (optionally
 /// `:variant`); anything that already exists on disk, names a `.base` file, or
@@ -159,14 +217,15 @@ pub fn dispatch_external(argv: Vec<String>) -> Result<()> {
 pub fn cmd_pull(args: PullArgs) -> Result<()> {
     let reg = MergedRegistry::bundled()?;
     let root = reg.root.clone();
-    let r = reg.resolve(&args.id, &args.revision, args.force)?;
+    let want = quant_token(&args);
+    let r = reg.resolve(&args.id, &args.revision, Some(&want), args.force)?;
 
     if args.dry_run {
-        print_plan(&r);
+        print_plan(&r, &want);
         return Ok(());
     }
 
-    match r {
+    match &r {
         ModelRef::Local { id, variant, path } => {
             eprintln!(
                 "{id} [{variant}] already installed: {}\n  (use --force to re-pull)",
@@ -174,24 +233,55 @@ pub fn cmd_pull(args: PullArgs) -> Result<()> {
             );
             Ok(())
         }
-        ModelRef::Catalog { .. } => pull_catalog(&root, &r),
+        // The catalog advertises one quant per id (the recommended default).
+        // Serve it directly when it's what the user wants; otherwise grab the
+        // requested quant straight from the same repo rather than silently
+        // handing back the cataloged one.
+        ModelRef::Catalog { id, hf_repo, revision, variant, .. } => {
+            if quant_tag(variant) == want {
+                pull_catalog(&root, &r)
+            } else {
+                let fetcher = HfFetcher::new()?;
+                let base_files = list_base_files(&fetcher, hf_repo, revision)?;
+                pull_base_direct(&root, &args, id, hf_repo, revision, &fetcher, &base_files)
+            }
+        }
+        // A raw HF repo: if it already hosts pre-converted `.base` artifacts
+        // (e.g. the basecompute org), download the matching one directly — no
+        // local conversion. Otherwise treat it as source safetensors.
         ModelRef::HuggingFace { id, repo, revision } => {
-            pull_and_convert(&root, &args, &id, &repo, &revision)
+            let fetcher = HfFetcher::new()?;
+            let base_files = list_base_files(&fetcher, repo, revision)?;
+            if base_files.is_empty() {
+                pull_and_convert(&root, &args, id, repo, revision)
+            } else {
+                pull_base_direct(&root, &args, id, repo, revision, &fetcher, &base_files)
+            }
         }
     }
 }
 
-fn print_plan(r: &ModelRef) {
+fn print_plan(r: &ModelRef, want: &str) {
     match r {
         ModelRef::Local { id, variant, path } => {
             println!("plan: {id} [{variant}] already installed at {}", path.display())
         }
-        ModelRef::Catalog { id, hf_repo, file, revision, variant, .. } => println!(
-            "plan: pull pre-converted {id} [{variant}] from {hf_repo}/{file}@{revision} (no conversion)"
-        ),
-        ModelRef::HuggingFace { id, repo, revision } => {
-            println!("plan: download {repo}@{revision} source + convert locally → {id}")
+        ModelRef::Catalog { id, hf_repo, file, revision, variant, .. } => {
+            if quant_tag(variant) == want {
+                println!(
+                    "plan: pull pre-converted {id} [{variant}] from {hf_repo}/{file}@{revision} (no conversion)"
+                )
+            } else {
+                println!(
+                    "plan: pull pre-converted {id} from {hf_repo}@{revision} \
+                     selecting the {want} .base (catalog default is {variant}; no conversion)"
+                )
+            }
         }
+        ModelRef::HuggingFace { id, repo, revision } => println!(
+            "plan: fetch {repo}@{revision} → {id} \
+             (download pre-converted .base if the repo has one, else convert source locally)"
+        ),
     }
 }
 
@@ -240,6 +330,48 @@ fn pull_catalog(root: &Path, r: &ModelRef) -> Result<()> {
         None,
         Some(got_sha),
     )?;
+    eprintln!("installed {id} [{variant}] → {}", out.display());
+    Ok(())
+}
+
+/// Fast path for any HF repo that already hosts pre-converted `.base`
+/// artifacts (the basecompute org, or anyone's): download the one matching
+/// the requested quant directly, no local conversion. This is what makes
+/// `basert pull <org>/<model>` work for `.base`-only repos that carry no
+/// safetensors + `config.json`.
+#[allow(clippy::too_many_arguments)]
+fn pull_base_direct(
+    root: &Path,
+    args: &PullArgs,
+    id: &str,
+    repo: &str,
+    revision: &str,
+    fetcher: &dyn Fetcher,
+    base_files: &[String],
+) -> Result<()> {
+    eprintln!("basert pull v{}", env!("CARGO_PKG_VERSION"));
+    eprintln!("  source:  {repo}@{revision} (HuggingFace, pre-converted .base)");
+
+    let want = quant_token(args);
+    let file = select_base_file(base_files, &want)?;
+    // Label the on-disk variant by the artifact's own quant when it carries
+    // one (so a `-Q8.base` never lands in a `default-q4` dir); otherwise fall
+    // back to what was requested.
+    let file_tag = quant_tag(&base_file_stem(file));
+    let variant_tag = if is_quant_tag(&file_tag) { file_tag } else { want };
+    let variant = format!("default-{variant_tag}");
+    eprintln!("  variant: {variant}");
+    eprintln!("  file:    {file}");
+
+    let vdir = cache::variant_dir(root, id, &variant)?;
+    std::fs::create_dir_all(&vdir)?;
+    let out = cache::base_artifact_path(&vdir);
+
+    let src = fetcher.get_file(repo, revision, file)?;
+    std::fs::copy(&src, &out).with_context(|| format!("installing into {}", out.display()))?;
+
+    let sha = crate::compute_sha256_streaming(&out).ok();
+    write_sidecar_for(&vdir, id, "huggingface", repo, None, revision, &variant, None, sha)?;
     eprintln!("installed {id} [{variant}] → {}", out.display());
     Ok(())
 }
@@ -487,6 +619,83 @@ fn human_size(bytes: u64) -> String {
 mod tests {
     use super::*;
     use base_hub::fetch::MockFetcher;
+
+    #[test]
+    fn quant_tag_extracts_last_segment() {
+        assert_eq!(quant_tag("default-q4"), "q4");
+        assert_eq!(quant_tag("base_q8"), "q8");
+        assert_eq!(quant_tag("Llama-3.2-1B-Instruct-Q4"), "q4");
+        assert_eq!(quant_tag("bf16"), "bf16");
+        assert_eq!(quant_tag("model"), "model");
+    }
+
+    #[test]
+    fn base_file_stem_strips_dir_and_ext() {
+        assert_eq!(base_file_stem("Foo-Q4.base"), "Foo-Q4");
+        assert_eq!(base_file_stem("sub/dir/Foo-Q8.base"), "Foo-Q8");
+        assert_eq!(base_file_stem("model.base"), "model");
+    }
+
+    #[test]
+    fn select_base_file_matches_quant_then_falls_back() {
+        let files = vec![
+            "Llama-3.2-1B-Instruct-Q4.base".to_string(),
+            "Llama-3.2-1B-Instruct-Q8.base".to_string(),
+        ];
+        assert_eq!(select_base_file(&files, "q4").unwrap(), &files[0]);
+        assert_eq!(select_base_file(&files, "q8").unwrap(), &files[1]);
+        // No match among several → error that lists what's available.
+        let err = select_base_file(&files, "q2").unwrap_err().to_string();
+        assert!(err.contains("q4") && err.contains("q8"), "{err}");
+        // Sole artifact → used regardless of requested quant.
+        let one = vec!["model.base".to_string()];
+        assert_eq!(select_base_file(&one, "q4").unwrap(), &one[0]);
+    }
+
+    #[test]
+    fn list_base_files_filters_to_base_only() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_dir = tmp.path().join("basecompute").join("m");
+        std::fs::create_dir_all(&repo_dir).unwrap();
+        for f in ["m-Q4.base", "m-Q8.base", "README.md", ".gitattributes"] {
+            std::fs::write(repo_dir.join(f), b"x").unwrap();
+        }
+        let fetcher = MockFetcher::new(tmp.path());
+        let mut got = list_base_files(&fetcher, "basecompute/m", "main").unwrap();
+        got.sort();
+        assert_eq!(got, vec!["m-Q4.base".to_string(), "m-Q8.base".to_string()]);
+    }
+
+    #[test]
+    fn pull_base_direct_installs_requested_quant() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Fake repo with both quants.
+        let repo_dir = tmp.path().join("basecompute").join("m");
+        std::fs::create_dir_all(&repo_dir).unwrap();
+        std::fs::write(repo_dir.join("m-Q4.base"), b"q4-bytes").unwrap();
+        std::fs::write(repo_dir.join("m-Q8.base"), b"q8-bytes").unwrap();
+        let fetcher = MockFetcher::new(tmp.path());
+        let base_files = list_base_files(&fetcher, "basecompute/m", "main").unwrap();
+
+        let root = tmp.path().join("cache");
+        let args = PullArgs {
+            id: "basecompute/m".into(),
+            profile: None,
+            target: TargetScheme::BaseQ8,
+            revision: "main".into(),
+            force: false,
+            dry_run: false,
+        };
+        pull_base_direct(&root, &args, "basecompute/m", "basecompute/m", "main", &fetcher, &base_files)
+            .unwrap();
+
+        // The Q8 artifact landed under the default-q8 variant dir.
+        let out = root.join("basecompute/m/default-q8/model.base");
+        assert!(out.exists(), "missing {}", out.display());
+        assert_eq!(std::fs::read(&out).unwrap(), b"q8-bytes");
+        // A provenance sidecar was written.
+        assert!(root.join("basecompute/m/default-q8/hub.json").exists());
+    }
 
     #[test]
     fn want_source_file_filters_safetensors_only() {

--- a/base-convert/crates/base-convert/src/hub.rs
+++ b/base-convert/crates/base-convert/src/hub.rs
@@ -127,33 +127,114 @@ fn looks_like_hub_id(token: &str) -> bool {
     id.contains('/')
 }
 
-/// Resolve a hub model reference (`org/model` or `org/model:variant`) to the
-/// installed `.base` artifact path. Errors when the id is hub-shaped but not
-/// installed, or ambiguous across variants, so the user gets an actionable
-/// message instead of a runtime "file not found".
-fn resolve_hub_model(token: &str) -> Result<PathBuf> {
-    let (id, variant) = token.split_once(':').map_or((token, None), |(i, v)| (i, Some(v)));
-    let reg = MergedRegistry::bundled()?;
-
-    if let Some(v) = variant {
-        return reg.local.installed_path(id, v).with_context(|| {
-            format!("model `{id}:{v}` is not installed — run `basert pull {id}` or see `basert list`")
-        });
+/// Map a requested id to the id we should actually pull, preferring a
+/// pre-converted artifact in the basecompute org. `Qwen/Qwen3-0.6B` →
+/// `basecompute/Qwen3-0.6B` when that's catalogued; otherwise the id is
+/// returned unchanged (convert-on-pull from the source repo).
+fn preconverted_id(reg: &MergedRegistry, id: &str) -> String {
+    if id.starts_with("basecompute/") {
+        return id.to_string();
     }
+    let name = id.rsplit('/').next().unwrap_or(id);
+    let candidate = format!("basecompute/{name}");
+    if reg.catalog.resolve(&candidate).is_some() {
+        candidate
+    } else {
+        id.to_string()
+    }
+}
 
+/// Map a quant tag (`q4`, `q8`, …) to the matching convert target.
+fn target_from_quant(tag: &str) -> TargetScheme {
+    match tag {
+        "q2" => TargetScheme::BaseQ2,
+        "q3" => TargetScheme::BaseQ3,
+        "q5" => TargetScheme::BaseQ5,
+        "q6" => TargetScheme::BaseQ6,
+        "q8" => TargetScheme::BaseQ8,
+        "bf16" => TargetScheme::Bf16,
+        "mxfp4" => TargetScheme::Mxfp4,
+        "nvfp4" => TargetScheme::Nvfp4,
+        _ => TargetScheme::BaseQ4,
+    }
+}
+
+/// The installed artifact path for `id`, if exactly one variant is present.
+/// `Ok(None)` when not installed; errors when several variants exist (the
+/// caller must disambiguate with `id:<variant>`).
+fn installed_single_path(reg: &MergedRegistry, id: &str) -> Result<Option<PathBuf>> {
     let installed = reg.local.list()?;
     let hits: Vec<&ModelEntry> = installed.iter().filter(|r| r.id == id).collect();
     match hits.as_slice() {
-        [] => bail!("model `{id}` is not installed — run `basert pull {id}` or see `basert list`"),
-        [one] => one
-            .path
-            .clone()
-            .with_context(|| format!("installed model `{id}` has no artifact path")),
+        [] => Ok(None),
+        [one] => Ok(Some(
+            one.path
+                .clone()
+                .with_context(|| format!("installed model `{id}` has no artifact path"))?,
+        )),
         many => {
             let variants = many.iter().map(|r| r.variant.as_str()).collect::<Vec<_>>().join(", ");
             bail!("model `{id}` has multiple installed variants ({variants}) — specify one as `{id}:<variant>`")
         }
     }
+}
+
+/// Fetch a not-yet-installed model on demand, then return its artifact path.
+/// Prefers the pre-converted basecompute mirror; otherwise converts the source
+/// repo on pull. Progress (download + quantization) is shown by `cmd_pull`.
+fn auto_pull_and_resolve(reg: &MergedRegistry, id: &str, want_variant: Option<&str>) -> Result<PathBuf> {
+    let pull_id = preconverted_id(reg, id);
+    let target = want_variant
+        .map(|v| target_from_quant(&quant_tag(v)))
+        .unwrap_or(TargetScheme::BaseQ4);
+
+    if pull_id != id {
+        eprintln!("{id}: not installed — using pre-converted {pull_id}");
+    } else {
+        eprintln!("{id}: not installed — fetching (download + convert if needed)");
+    }
+
+    cmd_pull(PullArgs {
+        id: pull_id.clone(),
+        profile: None,
+        target,
+        revision: "main".to_string(),
+        force: false,
+        dry_run: false,
+    })
+    .with_context(|| format!("auto-fetching {pull_id}"))?;
+
+    // Re-scan and return the freshly-installed artifact (registered under the
+    // pulled id, which may differ from the requested one).
+    let reg2 = MergedRegistry::bundled()?;
+    if let Some(v) = want_variant {
+        if let Some(p) = reg2.local.installed_path(&pull_id, v) {
+            return Ok(p);
+        }
+    }
+    installed_single_path(&reg2, &pull_id)?
+        .with_context(|| format!("fetched {pull_id} but could not locate the installed artifact"))
+}
+
+/// Resolve a hub model reference (`org/model` or `org/model:variant`) to the
+/// installed `.base` artifact path. When the model isn't installed yet it is
+/// fetched on demand — preferring the pre-converted basecompute mirror, else
+/// converting the source repo — so `basert chat`/`serve <id>` Just Works.
+fn resolve_hub_model(token: &str) -> Result<PathBuf> {
+    let (id, variant) = token.split_once(':').map_or((token, None), |(i, v)| (i, Some(v)));
+    let reg = MergedRegistry::bundled()?;
+
+    if let Some(v) = variant {
+        if let Some(p) = reg.local.installed_path(id, v) {
+            return Ok(p);
+        }
+        return auto_pull_and_resolve(&reg, id, Some(v));
+    }
+
+    if let Some(p) = installed_single_path(&reg, id)? {
+        return Ok(p);
+    }
+    auto_pull_and_resolve(&reg, id, None)
 }
 
 /// Rewrite every hub-id-shaped argument to the installed `.base` path so that
@@ -695,6 +776,35 @@ mod tests {
         assert_eq!(std::fs::read(&out).unwrap(), b"q8-bytes");
         // A provenance sidecar was written.
         assert!(root.join("basecompute/m/default-q8/hub.json").exists());
+    }
+
+    #[test]
+    fn preconverted_id_prefers_basecompute_mirror() {
+        let reg = MergedRegistry::bundled().unwrap();
+        // A source-org id with a catalogued basecompute counterpart maps to it.
+        assert_eq!(
+            preconverted_id(&reg, "Qwen/Qwen3-0.6B"),
+            "basecompute/Qwen3-0.6B"
+        );
+        // An already-basecompute id is unchanged.
+        assert_eq!(
+            preconverted_id(&reg, "basecompute/Qwen3-0.6B"),
+            "basecompute/Qwen3-0.6B"
+        );
+        // No catalogued counterpart → fall back to the source repo (convert-on-pull).
+        assert_eq!(
+            preconverted_id(&reg, "someorg/Definitely-Not-Catalogued-XYZ"),
+            "someorg/Definitely-Not-Catalogued-XYZ"
+        );
+    }
+
+    #[test]
+    fn target_from_quant_maps_known_tags() {
+        assert!(matches!(target_from_quant("q8"), TargetScheme::BaseQ8));
+        assert!(matches!(target_from_quant("q4"), TargetScheme::BaseQ4));
+        assert!(matches!(target_from_quant("bf16"), TargetScheme::Bf16));
+        // Unknown → q4 default.
+        assert!(matches!(target_from_quant("weird"), TargetScheme::BaseQ4));
     }
 
     #[test]

--- a/base-convert/crates/base-convert/src/main.rs
+++ b/base-convert/crates/base-convert/src/main.rs
@@ -1085,7 +1085,14 @@ fn convert_generic(
 
     let mut writer = BaseWriter::create(output, header).context("create writer")?;
 
+    let pb = indicatif::ProgressBar::new(mapped.len() as u64);
+    pb.set_style(
+        indicatif::ProgressStyle::with_template("  quantizing [{bar:28}] {pos}/{len} {msg}")
+            .expect("valid progress template")
+            .progress_chars("=>-"),
+    );
     for (src_name, canonical) in &mapped {
+        pb.set_message(canonical.clone());
         let shape = provider.source_shape(src_name)?;
 
         let mut f32s = provider
@@ -1310,7 +1317,10 @@ fn convert_generic(
         };
 
         writer.add_tensor(TensorPayload { entry, data });
+        pb.inc(1);
     }
+    pb.finish_and_clear();
+    eprintln!("  quantized {} tensors", mapped.len());
 
     // Multimodal towers — preserve their HF names verbatim and route
     // them into the mmproj sub-bundle. Tower weights stay on the same

--- a/base-convert/crates/base-hub/catalog.json
+++ b/base-convert/crates/base-hub/catalog.json
@@ -1,5 +1,340 @@
 {
   "schema": 1,
-  "updated": "2026-06-24",
-  "models": []
+  "updated": "2026-06-29",
+  "models": [
+    {
+      "id": "basecompute/Qwen3-0.6B",
+      "hf_repo": "basecompute/Qwen3-0.6B",
+      "file": "Qwen3-0.6B-Q4.base",
+      "source_repo": "Qwen/Qwen3-0.6B",
+      "arch": "qwen",
+      "quant": "default-q4",
+      "size": 430114816,
+      "sha256": "aeb9a2b16c1a5519895f99eec67e3d7c3347851d778a3663cfe80242ae87817e"
+    },
+    {
+      "id": "basecompute/Qwen3-0.6B",
+      "hf_repo": "basecompute/Qwen3-0.6B",
+      "file": "Qwen3-0.6B-Q8.base",
+      "source_repo": "Qwen/Qwen3-0.6B",
+      "arch": "qwen",
+      "quant": "default-q8",
+      "size": 782403584,
+      "sha256": "a562fd2b682206a208fb938df6951849a70829b4228b604ccdf381327a716370"
+    },
+    {
+      "id": "basecompute/Qwen3-4B",
+      "hf_repo": "basecompute/Qwen3-4B",
+      "file": "Qwen3-4B-Q4.base",
+      "source_repo": "Qwen/Qwen3-4B",
+      "arch": "qwen",
+      "quant": "default-q4",
+      "size": 2270401536,
+      "sha256": "df660a56b61bb68b940da100f9ad345a93d396df1955387e2f41f317e130e696"
+    },
+    {
+      "id": "basecompute/Qwen3-4B",
+      "hf_repo": "basecompute/Qwen3-4B",
+      "file": "Qwen3-4B-Q8.base",
+      "source_repo": "Qwen/Qwen3-4B",
+      "arch": "qwen",
+      "quant": "default-q8",
+      "size": 4155544576,
+      "sha256": "7898a470ac96c67b97e6330eb0f2b5fc00475247880a66e12b7640d9cc169b9a"
+    },
+    {
+      "id": "basecompute/Qwen3-30B-A3B-Thinking-2507",
+      "hf_repo": "basecompute/Qwen3-30B-A3B-Thinking-2507",
+      "file": "Qwen3-30B-A3B-Thinking-2507-Q4.base",
+      "source_repo": "Qwen/Qwen3-30B-A3B-Thinking-2507",
+      "arch": "qwen3_moe",
+      "quant": "default-q4",
+      "size": 17182330880,
+      "sha256": "52b5666ee1026b12d1d7c234ec5eedeb4deed1949caeb0c0f1e53e6d0259042e"
+    },
+    {
+      "id": "basecompute/Qwen3-30B-A3B-Thinking-2507",
+      "hf_repo": "basecompute/Qwen3-30B-A3B-Thinking-2507",
+      "file": "Qwen3-30B-A3B-Thinking-2507-Q8.base",
+      "source_repo": "Qwen/Qwen3-30B-A3B-Thinking-2507",
+      "arch": "qwen3_moe",
+      "quant": "default-q8",
+      "size": 31493787648,
+      "sha256": "5df2136010dcfedc36be6229770ad066b60fe5ec58825795bac9a6738b5567e8"
+    },
+    {
+      "id": "basecompute/gemma-3-1b-it",
+      "hf_repo": "basecompute/gemma-3-1b-it",
+      "file": "gemma-3-1b-it-Q4.base",
+      "source_repo": "google/gemma-3-1b-it",
+      "arch": "gemma3",
+      "quant": "default-q4",
+      "size": 579602688,
+      "sha256": "149ec28b4df637adda54064af2d7df753a3d55e500fcb710aef4c169a12ef387"
+    },
+    {
+      "id": "basecompute/gemma-3-1b-it",
+      "hf_repo": "basecompute/gemma-3-1b-it",
+      "file": "gemma-3-1b-it-Q8.base",
+      "source_repo": "google/gemma-3-1b-it",
+      "arch": "gemma3",
+      "quant": "default-q8",
+      "size": 1047890176,
+      "sha256": "d8e31808182c9e232660484dd5baa47d9fb711bc6e3ff48484dbaecf62a4238c"
+    },
+    {
+      "id": "basecompute/Llama-3.2-1B-Instruct",
+      "hf_repo": "basecompute/Llama-3.2-1B-Instruct",
+      "file": "Llama-3.2-1B-Instruct-Q4.base",
+      "source_repo": "meta-llama/Llama-3.2-1B-Instruct",
+      "arch": "llama",
+      "quant": "default-q4",
+      "size": 701861888,
+      "sha256": "292fe9db91c3a0da29e4d7e049eecc6fc30b0b9e009df3775b0f4894bac1a65e"
+    },
+    {
+      "id": "basecompute/Llama-3.2-1B-Instruct",
+      "hf_repo": "basecompute/Llama-3.2-1B-Instruct",
+      "file": "Llama-3.2-1B-Instruct-Q8.base",
+      "source_repo": "meta-llama/Llama-3.2-1B-Instruct",
+      "arch": "llama",
+      "quant": "default-q8",
+      "size": 1281118208,
+      "sha256": "67765adbe195378cda62ecea46c3cb2a6ab82d13709f4643f1abb0a70561c799"
+    },
+    {
+      "id": "basecompute/Llama-3.2-3B-Instruct",
+      "hf_repo": "basecompute/Llama-3.2-3B-Instruct",
+      "file": "Llama-3.2-3B-Instruct-Q4.base",
+      "source_repo": "meta-llama/Llama-3.2-3B-Instruct",
+      "arch": "llama",
+      "quant": "default-q4",
+      "size": 1814222848,
+      "sha256": "a0d5be46b5e13ce488e351cb8d769d3402250ee8adf3ff1fa41e70328f1fac8a"
+    },
+    {
+      "id": "basecompute/Llama-3.2-3B-Instruct",
+      "hf_repo": "basecompute/Llama-3.2-3B-Instruct",
+      "file": "Llama-3.2-3B-Instruct-Q8.base",
+      "source_repo": "meta-llama/Llama-3.2-3B-Instruct",
+      "arch": "llama",
+      "quant": "default-q8",
+      "size": 3320125440,
+      "sha256": "fe94e68856346a8016f83d142b5fac16555e180a6409f357b749e7f708ec7dea"
+    },
+    {
+      "id": "basecompute/gemma-4-E2B-it",
+      "hf_repo": "basecompute/gemma-4-E2B-it",
+      "file": "gemma-4-E2B-it-Q4.base",
+      "arch": "gemma4",
+      "quant": "default-q4",
+      "size": 2941140992,
+      "sha256": "785c3527ab6d33e4d2a1976e63ecc2bf13ceb0cab5b00ce375fd9cec2a971bc0"
+    },
+    {
+      "id": "basecompute/gemma-4-E2B-it",
+      "hf_repo": "basecompute/gemma-4-E2B-it",
+      "file": "gemma-4-E2B-it-Q8.base",
+      "arch": "gemma4",
+      "quant": "default-q8",
+      "size": 5334106112,
+      "sha256": "3e9a9c8629756b2513cf2de35e6a3c18604374085b999b7841c128d542af52d9"
+    },
+    {
+      "id": "basecompute/gemma-4-E4B-it",
+      "hf_repo": "basecompute/gemma-4-E4B-it",
+      "file": "gemma-4-E4B-it-Q4.base",
+      "arch": "gemma4",
+      "quant": "default-q4",
+      "size": 4558422016,
+      "sha256": "68348e8a9d4d0a00f9fe9e3ea80835f9d45d2165e1fc407f68366bf72b64bb8f"
+    },
+    {
+      "id": "basecompute/gemma-4-E4B-it",
+      "hf_repo": "basecompute/gemma-4-E4B-it",
+      "file": "gemma-4-E4B-it-Q8.base",
+      "arch": "gemma4",
+      "quant": "default-q8",
+      "size": 8297676800,
+      "sha256": "c293bd1e3479b293fab353783af6d96dc285d3b07b688034eb544e36c99c9ef7"
+    },
+    {
+      "id": "basecompute/gemma-4-26B-A4B-it",
+      "hf_repo": "basecompute/gemma-4-26B-A4B-it",
+      "file": "gemma-4-26B-A4B-it-Q4.base",
+      "arch": "gemma4",
+      "quant": "default-q4",
+      "size": 16108079360,
+      "sha256": "efabbac27832f43d17eaac05c9a5c32545c9a02bea975836f038d32de8368782"
+    },
+    {
+      "id": "basecompute/gemma-4-26B-A4B-it",
+      "hf_repo": "basecompute/gemma-4-26B-A4B-it",
+      "file": "gemma-4-26B-A4B-it-Q8.base",
+      "arch": "gemma4",
+      "quant": "default-q8",
+      "size": 26656278784,
+      "sha256": "c2f13d6d299cb8a18e5c41929d974c348846214d37e2acbdf4865e8a71a4e411"
+    },
+    {
+      "id": "basecompute/nomic-embed-text-v1.5",
+      "hf_repo": "basecompute/nomic-embed-text-v1.5",
+      "file": "nomic-embed-text-v1.5-Q4.base",
+      "source_repo": "nomic-ai/nomic-embed-text-v1.5",
+      "arch": "nomic-bert",
+      "quant": "default-q4",
+      "size": 78218752,
+      "sha256": "23b7ca9d4026bdf5c8b6d53faa761be66e6c475acdd7c59ebdc0447f2b231175"
+    },
+    {
+      "id": "basecompute/nomic-embed-text-v1.5",
+      "hf_repo": "basecompute/nomic-embed-text-v1.5",
+      "file": "nomic-embed-text-v1.5-Q8.base",
+      "source_repo": "nomic-ai/nomic-embed-text-v1.5",
+      "arch": "nomic-bert",
+      "quant": "default-q8",
+      "size": 142296576,
+      "sha256": "6239447345780bcf8af6bd410eaa4468bec55059899ccde63f86c060425fe422"
+    },
+    {
+      "id": "basecompute/Qwen3-1.7B",
+      "hf_repo": "basecompute/Qwen3-1.7B",
+      "file": "Qwen3-1.7B-Q4.base",
+      "source_repo": "Qwen/Qwen3-1.7B",
+      "arch": "qwen",
+      "quant": "default-q4",
+      "size": 1150128128,
+      "sha256": "a761c553797d0fb5aaf79878a66ed410a8a52bd311983a1310d9e8f3c70eab81"
+    },
+    {
+      "id": "basecompute/Qwen3-1.7B",
+      "hf_repo": "basecompute/Qwen3-1.7B",
+      "file": "Qwen3-1.7B-Q8.base",
+      "source_repo": "Qwen/Qwen3-1.7B",
+      "arch": "qwen",
+      "quant": "default-q8",
+      "size": 2102464512,
+      "sha256": "f54c1ed6a8cf757a70d9006df3a95c05f7b68de11157bf8e5a7dd671e0fb5bcc"
+    },
+    {
+      "id": "basecompute/Qwen3-8B",
+      "hf_repo": "basecompute/Qwen3-8B",
+      "file": "Qwen3-8B-Q4.base",
+      "source_repo": "Qwen/Qwen3-8B",
+      "arch": "qwen",
+      "quant": "default-q4",
+      "size": 4614987776,
+      "sha256": "da84d54a5c55d3c1c4c52064cac1d0fd2104584bf1a12cdb8e4179d91a797144"
+    },
+    {
+      "id": "basecompute/Qwen3-8B",
+      "hf_repo": "basecompute/Qwen3-8B",
+      "file": "Qwen3-8B-Q8.base",
+      "source_repo": "Qwen/Qwen3-8B",
+      "arch": "qwen",
+      "quant": "default-q8",
+      "size": 8454250496,
+      "sha256": "37785e5d3bcaacb4a3c8caf298d972d5812cfdbf4c6b800db28cfa5db5477ad6"
+    },
+    {
+      "id": "basecompute/Llama-3.1-8B-Instruct",
+      "hf_repo": "basecompute/Llama-3.1-8B-Instruct",
+      "file": "Llama-3.1-8B-Instruct-Q4.base",
+      "source_repo": "meta-llama/Llama-3.1-8B-Instruct",
+      "arch": "llama",
+      "quant": "default-q4",
+      "size": 4524154880,
+      "sha256": "5d46c1a7e9247f095ee2e9955b1cae8bcea383d4417ecc3b26c5ce6fdd3babdc"
+    },
+    {
+      "id": "basecompute/Llama-3.1-8B-Instruct",
+      "hf_repo": "basecompute/Llama-3.1-8B-Instruct",
+      "file": "Llama-3.1-8B-Instruct-Q8.base",
+      "source_repo": "meta-llama/Llama-3.1-8B-Instruct",
+      "arch": "llama",
+      "quant": "default-q8",
+      "size": 8288215040,
+      "sha256": "682586936a9f29bb37055e2ff2ec724d1328435dec4b94a566793eb20bbd3d1c"
+    },
+    {
+      "id": "basecompute/TinyLlama-1.1B-Chat-v1.0",
+      "hf_repo": "basecompute/TinyLlama-1.1B-Chat-v1.0",
+      "file": "TinyLlama-1.1B-Chat-v1.0-Q4.base",
+      "source_repo": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+      "arch": "llama",
+      "quant": "default-q4",
+      "size": 620695552,
+      "sha256": "68e8e5a5cb958b11e4500dc6833deacefcc70ed742a0fb3d8632e2f49d3484dc"
+    },
+    {
+      "id": "basecompute/TinyLlama-1.1B-Chat-v1.0",
+      "hf_repo": "basecompute/TinyLlama-1.1B-Chat-v1.0",
+      "file": "TinyLlama-1.1B-Chat-v1.0-Q8.base",
+      "source_repo": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+      "arch": "llama",
+      "quant": "default-q8",
+      "size": 1136300032,
+      "sha256": "55182c65b7cb4c5f1f45bd39771adf361251770764f10666e8b4e4b647883e8e"
+    },
+    {
+      "id": "basecompute/SmolLM2-1.7B-Instruct",
+      "hf_repo": "basecompute/SmolLM2-1.7B-Instruct",
+      "file": "SmolLM2-1.7B-Instruct-Q4.base",
+      "source_repo": "HuggingFaceTB/SmolLM2-1.7B-Instruct",
+      "arch": "llama",
+      "quant": "default-q4",
+      "size": 964825088,
+      "sha256": "09c4dffbc6379f20cbe31d63d874a2963cd572b0dcbb9526234e733d3a4051c8"
+    },
+    {
+      "id": "basecompute/SmolLM2-1.7B-Instruct",
+      "hf_repo": "basecompute/SmolLM2-1.7B-Instruct",
+      "file": "SmolLM2-1.7B-Instruct-Q8.base",
+      "source_repo": "HuggingFaceTB/SmolLM2-1.7B-Instruct",
+      "arch": "llama",
+      "quant": "default-q8",
+      "size": 1766985728,
+      "sha256": "a7c3653125ffa548221ac9d33e658c09746854515eecbeab1943073e62d293a3"
+    },
+    {
+      "id": "basecompute/Mistral-7B-Instruct-v0.3",
+      "hf_repo": "basecompute/Mistral-7B-Instruct-v0.3",
+      "file": "Mistral-7B-Instruct-v0.3-Q4.base",
+      "source_repo": "mistralai/Mistral-7B-Instruct-v0.3",
+      "arch": "llama",
+      "quant": "default-q4",
+      "size": 4079362048,
+      "sha256": "dbece3c8846afc89e282a98796b7651227557e7eb1645de139e12917b04d175d"
+    },
+    {
+      "id": "basecompute/Mistral-7B-Instruct-v0.3",
+      "hf_repo": "basecompute/Mistral-7B-Instruct-v0.3",
+      "file": "Mistral-7B-Instruct-v0.3-Q8.base",
+      "source_repo": "mistralai/Mistral-7B-Instruct-v0.3",
+      "arch": "llama",
+      "quant": "default-q8",
+      "size": 7476748288,
+      "sha256": "3f2b5589475dd5da34b3433abec085b16d56818dba22748b08d39bd169f5243b"
+    },
+    {
+      "id": "basecompute/Ministral-8B-Instruct-2410",
+      "hf_repo": "basecompute/Ministral-8B-Instruct-2410",
+      "file": "Ministral-8B-Instruct-2410-Q4.base",
+      "source_repo": "mistralai/Ministral-8B-Instruct-2410",
+      "arch": "llama",
+      "quant": "default-q4",
+      "size": 4519763968,
+      "sha256": "32804841f1395f3e4faf028849d6dfcae190c716578bd29e6c2510cc6eaa945d"
+    },
+    {
+      "id": "basecompute/Ministral-8B-Instruct-2410",
+      "hf_repo": "basecompute/Ministral-8B-Instruct-2410",
+      "file": "Ministral-8B-Instruct-2410-Q8.base",
+      "source_repo": "mistralai/Ministral-8B-Instruct-2410",
+      "arch": "llama",
+      "quant": "default-q8",
+      "size": 8278908928,
+      "sha256": "cdd104a18efa331bdb0e8cb71460f6f6db7bbb4be3b73dfd011759da72a01bc0"
+    }
+  ]
 }

--- a/base-convert/crates/base-hub/catalog.json
+++ b/base-convert/crates/base-hub/catalog.json
@@ -257,46 +257,6 @@
       "sha256": "682586936a9f29bb37055e2ff2ec724d1328435dec4b94a566793eb20bbd3d1c"
     },
     {
-      "id": "basecompute/TinyLlama-1.1B-Chat-v1.0",
-      "hf_repo": "basecompute/TinyLlama-1.1B-Chat-v1.0",
-      "file": "TinyLlama-1.1B-Chat-v1.0-Q4.base",
-      "source_repo": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
-      "arch": "llama",
-      "quant": "default-q4",
-      "size": 620695552,
-      "sha256": "68e8e5a5cb958b11e4500dc6833deacefcc70ed742a0fb3d8632e2f49d3484dc"
-    },
-    {
-      "id": "basecompute/TinyLlama-1.1B-Chat-v1.0",
-      "hf_repo": "basecompute/TinyLlama-1.1B-Chat-v1.0",
-      "file": "TinyLlama-1.1B-Chat-v1.0-Q8.base",
-      "source_repo": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
-      "arch": "llama",
-      "quant": "default-q8",
-      "size": 1136300032,
-      "sha256": "55182c65b7cb4c5f1f45bd39771adf361251770764f10666e8b4e4b647883e8e"
-    },
-    {
-      "id": "basecompute/SmolLM2-1.7B-Instruct",
-      "hf_repo": "basecompute/SmolLM2-1.7B-Instruct",
-      "file": "SmolLM2-1.7B-Instruct-Q4.base",
-      "source_repo": "HuggingFaceTB/SmolLM2-1.7B-Instruct",
-      "arch": "llama",
-      "quant": "default-q4",
-      "size": 964825088,
-      "sha256": "09c4dffbc6379f20cbe31d63d874a2963cd572b0dcbb9526234e733d3a4051c8"
-    },
-    {
-      "id": "basecompute/SmolLM2-1.7B-Instruct",
-      "hf_repo": "basecompute/SmolLM2-1.7B-Instruct",
-      "file": "SmolLM2-1.7B-Instruct-Q8.base",
-      "source_repo": "HuggingFaceTB/SmolLM2-1.7B-Instruct",
-      "arch": "llama",
-      "quant": "default-q8",
-      "size": 1766985728,
-      "sha256": "a7c3653125ffa548221ac9d33e658c09746854515eecbeab1943073e62d293a3"
-    },
-    {
       "id": "basecompute/Mistral-7B-Instruct-v0.3",
       "hf_repo": "basecompute/Mistral-7B-Instruct-v0.3",
       "file": "Mistral-7B-Instruct-v0.3-Q4.base",
@@ -315,26 +275,6 @@
       "quant": "default-q8",
       "size": 7476748288,
       "sha256": "3f2b5589475dd5da34b3433abec085b16d56818dba22748b08d39bd169f5243b"
-    },
-    {
-      "id": "basecompute/Ministral-8B-Instruct-2410",
-      "hf_repo": "basecompute/Ministral-8B-Instruct-2410",
-      "file": "Ministral-8B-Instruct-2410-Q4.base",
-      "source_repo": "mistralai/Ministral-8B-Instruct-2410",
-      "arch": "llama",
-      "quant": "default-q4",
-      "size": 4519763968,
-      "sha256": "32804841f1395f3e4faf028849d6dfcae190c716578bd29e6c2510cc6eaa945d"
-    },
-    {
-      "id": "basecompute/Ministral-8B-Instruct-2410",
-      "hf_repo": "basecompute/Ministral-8B-Instruct-2410",
-      "file": "Ministral-8B-Instruct-2410-Q8.base",
-      "source_repo": "mistralai/Ministral-8B-Instruct-2410",
-      "arch": "llama",
-      "quant": "default-q8",
-      "size": 8278908928,
-      "sha256": "cdd104a18efa331bdb0e8cb71460f6f6db7bbb4be3b73dfd011759da72a01bc0"
     }
   ]
 }

--- a/base-convert/crates/base-hub/src/catalog.rs
+++ b/base-convert/crates/base-hub/src/catalog.rs
@@ -84,6 +84,26 @@ mod tests {
     }
 
     #[test]
+    fn bundled_catalog_is_populated_and_resolves_default_q4() {
+        let cat = Catalog::bundled().unwrap();
+        assert!(!cat.models.is_empty(), "bundled catalog should not be empty");
+        // Every entry carries the fields the resolver/installer need.
+        for e in &cat.models {
+            assert!(e.id.starts_with("basecompute/"), "id: {}", e.id);
+            assert!(e.file.ends_with(".base"), "file: {}", e.file);
+            assert!(e.arch.is_some(), "arch missing for {}", e.id);
+            assert!(e.sha256.is_some(), "sha256 missing for {}", e.id);
+        }
+        // find() returns the first id match — entries are ordered q4-first so
+        // the recommended default is q4.
+        let e = cat
+            .find("basecompute/Llama-3.2-1B-Instruct")
+            .expect("Llama-3.2-1B-Instruct should be catalogued");
+        assert_eq!(e.quant, "default-q4");
+        assert_eq!(e.arch.as_deref(), Some("llama"));
+    }
+
+    #[test]
     fn find_matches_exact_and_ci() {
         let cat = Catalog::from_json(
             r#"{"schema":1,"updated":"x","models":[

--- a/base-convert/crates/base-hub/src/registry.rs
+++ b/base-convert/crates/base-hub/src/registry.rs
@@ -262,12 +262,33 @@ impl MergedRegistry {
 
     /// Resolve an id to a concrete [`ModelRef`].
     ///
-    /// With `force`, the already-installed shortcut is skipped so the model
-    /// is re-fetched/re-converted. A bare HF `org/model` id that isn't in the
-    /// catalog falls through to convert-on-pull.
-    pub fn resolve(&self, id: &str, revision: &str, force: bool) -> Result<ModelRef> {
+    /// `want_quant` is the quant the caller is after (`q4`, `q8`, …); when set,
+    /// the already-installed shortcut only fires for *that* quant — so asking
+    /// for q8 never silently returns an installed q4. With `force`, the
+    /// shortcut is skipped entirely so the model is re-fetched/re-converted.
+    /// A bare HF `org/model` id that isn't in the catalog falls through to
+    /// convert-on-pull.
+    pub fn resolve(
+        &self,
+        id: &str,
+        revision: &str,
+        want_quant: Option<&str>,
+        force: bool,
+    ) -> Result<ModelRef> {
         if !force {
-            if let Some(ModelRef::Catalog { variant, .. }) = self.catalog.resolve(id) {
+            // Variants installed by every pull path are named `default-<quant>`
+            // (or the catalog entry's own quant). When the caller names a quant,
+            // honour exactly that one.
+            if let Some(want) = want_quant {
+                let variant = format!("default-{want}");
+                if let Some(path) = self.local.installed_path(id, &variant) {
+                    return Ok(ModelRef::Local {
+                        id: id.to_string(),
+                        variant,
+                        path,
+                    });
+                }
+            } else if let Some(ModelRef::Catalog { variant, .. }) = self.catalog.resolve(id) {
                 if let Some(path) = self.local.installed_path(id, &variant) {
                     return Ok(ModelRef::Local {
                         id: id.to_string(),
@@ -334,7 +355,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let reg = MergedRegistry::new(tmp.path(), catalog_with_one());
 
-        match reg.resolve("basecompute/demo", "main", false).unwrap() {
+        match reg.resolve("basecompute/demo", "main", None, false).unwrap() {
             ModelRef::Catalog {
                 hf_repo, variant, ..
             } => {
@@ -344,13 +365,35 @@ mod tests {
             other => panic!("expected Catalog, got {other:?}"),
         }
         match reg
-            .resolve("meta-llama/Llama-3.2-1B", "main", false)
+            .resolve("meta-llama/Llama-3.2-1B", "main", None, false)
             .unwrap()
         {
             ModelRef::HuggingFace { repo, .. } => assert_eq!(repo, "meta-llama/Llama-3.2-1B"),
             other => panic!("expected HuggingFace, got {other:?}"),
         }
-        assert!(reg.resolve("single-segment", "main", false).is_err());
+        assert!(reg.resolve("single-segment", "main", None, false).is_err());
+    }
+
+    #[test]
+    fn resolve_installed_shortcut_is_quant_aware() {
+        let tmp = tempfile::tempdir().unwrap();
+        let reg = MergedRegistry::new(tmp.path(), catalog_with_one());
+        // Only the q4 variant is on disk.
+        let vdir = cache::variant_dir(tmp.path(), "basecompute/demo", "default-q4").unwrap();
+        std::fs::create_dir_all(&vdir).unwrap();
+        std::fs::write(cache::base_artifact_path(&vdir), b"installed-q4").unwrap();
+
+        // Asking for q4 → the installed artifact.
+        assert!(matches!(
+            reg.resolve("basecompute/demo", "main", Some("q4"), false).unwrap(),
+            ModelRef::Local { .. }
+        ));
+        // Asking for q8 must NOT return the installed q4 — it falls through to
+        // the catalog so the right quant gets fetched.
+        assert!(matches!(
+            reg.resolve("basecompute/demo", "main", Some("q8"), false).unwrap(),
+            ModelRef::Catalog { .. }
+        ));
     }
 
     #[test]
@@ -387,13 +430,13 @@ mod tests {
         std::fs::create_dir_all(&vdir).unwrap();
         std::fs::write(cache::base_artifact_path(&vdir), b"not a real base").unwrap();
 
-        match reg.resolve("basecompute/demo", "main", false).unwrap() {
+        match reg.resolve("basecompute/demo", "main", None, false).unwrap() {
             ModelRef::Local { variant, .. } => assert_eq!(variant, "default-q4"),
             other => panic!("expected Local, got {other:?}"),
         }
         // With force, the local shortcut is skipped.
         assert!(matches!(
-            reg.resolve("basecompute/demo", "main", true).unwrap(),
+            reg.resolve("basecompute/demo", "main", None, true).unwrap(),
             ModelRef::Catalog { .. }
         ));
     }


### PR DESCRIPTION
Public mirror of the hub changes from `basecompute/baseRT-internal` (PR #17).

## Problem
`basert pull basecompute/<model>` couldn't reach the pre-converted `.base` repos: the resolver only fast-pathed a `.base` for ids in `catalog.json` (empty), so every repo fell through to convert-on-pull, which needs source safetensors + `config.json` and failed with *"no config.json"*.

## Changes (all under the mirrored `base-convert/`)
1. **Auto-detect pre-converted `.base` on pull.** Any HF repo is listed first; if it hosts `.base` artifacts, download the one matching the requested quant directly — no local conversion. Repos with only safetensors still convert-on-pull.
2. **Quant-aware `resolve()`.** `--target base-q8` no longer silently returns an installed/cataloged q4; variants are uniformly named `default-<quant>`.
3. **Populate `catalog.json`** with the 17 public `basecompute/*` models (Q4+Q8, `size` + `sha256`) → `basert list --remote` shows 34 rows and the q4 fast-path verifies integrity.
4. **Convert progress bar** — per-tensor `indicatif` bar over the `convert_hf` quantization loop.

## Tests
base-convert + base-hub unit suites pass standalone; new tests cover quant-tag/`.base` selection, `pull_base_direct`, quant-aware `resolve`, and populated-catalog resolution. No engine internals or tuned profiles touched.