### PR TITLE
docs: document quant-variant selection for serve/chat

### DIFF
--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -119,6 +119,19 @@ See [Signing & verification](../guides/signing.md).
 
 These exec `basert-<cmd>`. Full flags in their guides.
 
+**Selecting a quant variant.** For the model-taking commands (`serve`, `chat`,
+`complete`, `bench`, `profile`), choose which quant build to load with an inline
+`:variant` on the hub id, or the `--variant` flag:
+
+```sh
+basert serve basecompute/gemma-4-E2B-it:default-q8
+basert serve basecompute/gemma-4-E2B-it --variant default-q8   # equivalent
+```
+
+Run `basert list` to see installed variants (`default-q4`, `default-q8`, …). An
+uninstalled variant is fetched on demand. The inline `:variant` wins if both are
+given.
+
 ### `basert serve`
 
 OpenAI-compatible HTTP server. See [Serving an API](../guides/serving.md).

--- a/docs/guides/serving.md
+++ b/docs/guides/serving.md
@@ -15,6 +15,20 @@ basert serve --model Qwen/Qwen3-4B --model Qwen/Qwen3-0.6B --api-key "$KEY"
 
 See the full list of endpoints in the [Server API reference](../reference/server-api.md).
 
+## Choosing a quant build
+
+Pick which quant variant to serve with an inline `:variant` on the id, or the
+`--variant` flag. Dense models ship `default-q4` and `default-q8`; MoE models are
+q4-only.
+
+```sh
+basert serve basecompute/gemma-4-E2B-it:default-q8 --max-context 16000
+# equivalently:
+basert serve basecompute/gemma-4-E2B-it --variant default-q8 --max-context 16000
+```
+
+`basert list` shows installed variants; an uninstalled one is pulled on demand.
+
 ## Core flags
 
 | Flag | Default | Purpose |


### PR DESCRIPTION
Documents how to pick a quant build when serving/chatting — previously undocumented.

## Changes
- **`docs/cli/reference.md`** — a "Selecting a quant variant" note under the runtime commands, covering both forms.
- **`docs/guides/serving.md`** — a "Choosing a quant build" section with examples.

```sh
basert serve basecompute/gemma-4-E2B-it:default-q8        # inline (works today)
basert serve basecompute/gemma-4-E2B-it --variant default-q8   # flag
```

## Dependency
The inline `:variant` selector works in the current CLI. The **`--variant` flag** is added by basecompute/baseRT-internal#32 — merge/ship that (and mirror it) before this is fully accurate. The inline form covers users in the meantime.

Once merged, the docs site (docs.basecompute.co) picks this up on its next sync.