### PR TITLE
ci(benchmark): fix engine asset pattern casing (baseRT→basert)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -25,8 +25,8 @@ jobs:
         run: |
           mkdir -p build
           gh release download --repo ${{ github.repository }} \
-            --pattern 'baseRT-engine-macos-arm64*.tar.gz' -D build
-          tar -xzf build/baseRT-engine-macos-arm64*.tar.gz -C build
+            --pattern 'basert-engine-macos-arm64*.tar.gz' -D build
+          tar -xzf build/basert-engine-macos-arm64*.tar.gz -C build
         env:
           GH_TOKEN: ${{ github.token }}
       - name: Fetch model


### PR DESCRIPTION
The Benchmark workflow's **Fetch engine release** step failed with `no assets match the file pattern`.

**Cause:** release assets are published as `basert-engine-macos-arm64-<ver>.tar.gz` (lowercase, post-rebrand), but the workflow still grepped for `baseRT-engine-macos-arm64*.tar.gz` (camelCase).

**Fix:** match the actual asset name on both the `gh release download --pattern` and the `tar -xzf` glob.

Verified against `v0.1.4` assets: `basert-engine-macos-arm64-0.1.4.tar.gz` (+ `.sha256`).