### PR TITLE
catalog: add basecompute/Qwen3.5-2B (Q4 + Q8)

### DIFF
--- a/base-convert/crates/base-hub/catalog.json
+++ b/base-convert/crates/base-hub/catalog.json
@@ -325,6 +325,26 @@
       "quant": "default-q4",
       "size": 17182920704,
       "sha256": "7b294daeff8ba6e097f6cebe9f56c7b71f32476765a3f614eb256ef9d8c6ffce"
+    },
+    {
+      "id": "basecompute/Qwen3.5-2B",
+      "hf_repo": "basecompute/Qwen3.5-2B",
+      "source_repo": "Qwen/Qwen3.5-2B",
+      "arch": "qwen35",
+      "file": "Qwen3.5-2B-Q4.base",
+      "quant": "default-q4",
+      "size": 1266810880,
+      "sha256": "1c95f41730d5713fcb886a71d2481a29ff1a6e2fc9cea8a4d9ddbe29082fa262"
+    },
+    {
+      "id": "basecompute/Qwen3.5-2B",
+      "hf_repo": "basecompute/Qwen3.5-2B",
+      "source_repo": "Qwen/Qwen3.5-2B",
+      "arch": "qwen35",
+      "file": "Qwen3.5-2B-Q8.base",
+      "quant": "default-q8",
+      "size": 2301460480,
+      "sha256": "d4cf325278e873b3e0aefc18c5eff0a863f12fee5a82f0ac2f2e5ebce4067f3c"
     }
   ]
 }


### PR DESCRIPTION
Adds Qwen3.5-2B to the model catalog (Q4 + Q8, sha256 from the HF tree). Runs on the 0.1.6 engine.