### PR TITLE
sync: engine 0.1.7 version stamps

### DIFF
--- a/bindings/swift/Sources/CBaseRT/include/baseRT.h
+++ b/bindings/swift/Sources/CBaseRT/include/baseRT.h
@@ -64,7 +64,7 @@ extern "C" {
 
 #define BASERT_VERSION_MAJOR 0
 #define BASERT_VERSION_MINOR 1
-#define BASERT_VERSION_PATCH 6
+#define BASERT_VERSION_PATCH 7
 
 /// Compile-time version, packed as `(MAJOR<<16) | (MINOR<<8) | PATCH`.
 /// Useful for `#if BASERT_VERSION >= 0x000200` feature checks.

--- a/include/baseRT/baseRT.h
+++ b/include/baseRT/baseRT.h
@@ -64,7 +64,7 @@ extern "C" {
 
 #define BASERT_VERSION_MAJOR 0
 #define BASERT_VERSION_MINOR 1
-#define BASERT_VERSION_PATCH 6
+#define BASERT_VERSION_PATCH 7
 
 /// Compile-time version, packed as `(MAJOR<<16) | (MINOR<<8) | PATCH`.
 /// Useful for `#if BASERT_VERSION >= 0x000200` feature checks.


### PR DESCRIPTION
Follow-up to #24: `BASERT_VERSION_PATCH` in the public header + swift mirror was still 6. Matches the re-cut v0.1.7 engine release.