### PR TITLE
sync: headers and bindings for 0.2.1

### DIFF
--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baseRT/node",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "description": "Node.js bindings for BaseRT — LLM inference engine for Apple Silicon (Metal)",
   "main": "dist/index.js",

--- a/bindings/node/src/__tests__/baseRT.test.ts
+++ b/bindings/node/src/__tests__/baseRT.test.ts
@@ -10,8 +10,14 @@
 import koffi from "koffi";
 import { __internal, type SamplingConfig } from "../index";
 
-const { ModelConfigC, SamplingConfigC, GenerationStatsC, TranscribeStatsC, toSamplingC } =
-  __internal;
+const {
+  ModelConfigC,
+  SamplingConfigC,
+  GenerationStatsC,
+  TranscribeStatsC,
+  TranscribeSegmentC,
+  toSamplingC,
+} = __internal;
 
 describe("C struct ABI (offsets match include/baseRT/types.h)", () => {
   test("BaseRTModelConfig includes sliding_window and places architecture at offset 60", () => {
@@ -62,6 +68,15 @@ describe("C struct ABI (offsets match include/baseRT/types.h)", () => {
 
   test("BaseRTTranscribeStats is 20 bytes (5 x 4-byte fields)", () => {
     expect(koffi.sizeof(TranscribeStatsC)).toBe(20);
+  });
+
+  test("BaseRTTranscribeSegment is 32 bytes with text at offset 8", () => {
+    // 2 x int, 8-byte-aligned char*, 4 x float — matches the C struct in
+    // include/baseRT/baseRT.h.
+    expect(koffi.sizeof(TranscribeSegmentC)).toBe(32);
+    expect(koffi.offsetof(TranscribeSegmentC, "text")).toBe(8);
+    expect(koffi.offsetof(TranscribeSegmentC, "avg_logprob")).toBe(16);
+    expect(koffi.offsetof(TranscribeSegmentC, "temperature")).toBe(28);
   });
 });
 

--- a/bindings/node/src/index.ts
+++ b/bindings/node/src/index.ts
@@ -207,6 +207,16 @@ const TranscribeStatsC = koffi.struct("BaseRTTranscribeStats", {
   total_ms: "float",
 });
 
+const TranscribeSegmentC = koffi.struct("BaseRTTranscribeSegment", {
+  start_ms: "int",
+  end_ms: "int",
+  text: "const char *",
+  avg_logprob: "float",
+  no_speech_prob: "float",
+  compression_ratio: "float",
+  temperature: "float",
+});
+
 // bool (*)(uint32_t token_id, const char *text, void *user_data)
 const TokenCallbackC = koffi.proto(
   "bool TokenCallback(uint32_t token_id, const char *text, void *user_data)"
@@ -286,6 +296,22 @@ export interface TranscribeStats {
 export interface TranscribeResult {
   text: string;
   stats: TranscribeStats;
+}
+
+/**
+ * One segment of the last transcription (verbose_json surface).
+ * avgLogprob / noSpeechProb / compressionRatio / temperature are
+ * window-level values applied to every segment decoded in that 30 s window
+ * (the engine's documented approximation).
+ */
+export interface TranscribeSegment {
+  startMs: number;
+  endMs: number;
+  text: string;
+  avgLogprob: number;
+  noSpeechProb: number;
+  compressionRatio: number;
+  temperature: number;
 }
 
 export type TokenCallback = (tokenId: number, text: string) => boolean;
@@ -397,19 +423,33 @@ interface BaseRTLib {
   baseRT_chat_template: (model: unknown) => string;
   baseRT_is_whisper: (model: unknown) => boolean;
   baseRT_set_timestamps: (model: unknown, enabled: boolean) => void;
+  baseRT_set_task: (model: unknown, task: string) => boolean;
+  baseRT_set_initial_prompt: (model: unknown, text: string | null) => void;
+  baseRT_set_condition_on_previous_text: (
+    model: unknown,
+    enabled: boolean
+  ) => void;
+  baseRT_transcribe_language: (model: unknown) => string;
+  baseRT_transcribe_audio_duration_ms: (model: unknown) => number;
+  baseRT_transcribe_segment_count: (model: unknown) => number;
+  baseRT_transcribe_segment: (
+    model: unknown,
+    index: number,
+    out: Record<string, unknown>
+  ) => boolean;
   baseRT_transcribe: (
     model: unknown,
     wavPath: string,
     language: string | null,
     statsOut: Record<string, unknown>
-  ) => string;
+  ) => string | null;
   baseRT_transcribe_pcm: (
     model: unknown,
     samples: Float32Array,
     n: number,
     language: string | null,
     statsOut: Record<string, unknown>
-  ) => string;
+  ) => string | null;
   baseRT_transcribe_stream: (
     model: unknown,
     wavPath: string,
@@ -505,6 +545,25 @@ function lib(): BaseRTLib {
     ),
     baseRT_is_whisper: k.func("bool baseRT_is_whisper(void *)"),
     baseRT_set_timestamps: k.func("void baseRT_set_timestamps(void *, bool)"),
+    baseRT_set_task: k.func("bool baseRT_set_task(void *, const char *)"),
+    baseRT_set_initial_prompt: k.func(
+      "void baseRT_set_initial_prompt(void *, const char *)"
+    ),
+    baseRT_set_condition_on_previous_text: k.func(
+      "void baseRT_set_condition_on_previous_text(void *, bool)"
+    ),
+    baseRT_transcribe_language: k.func(
+      "const char *baseRT_transcribe_language(void *)"
+    ),
+    baseRT_transcribe_audio_duration_ms: k.func(
+      "int baseRT_transcribe_audio_duration_ms(void *)"
+    ),
+    baseRT_transcribe_segment_count: k.func(
+      "int baseRT_transcribe_segment_count(void *)"
+    ),
+    baseRT_transcribe_segment: k.func(
+      "bool baseRT_transcribe_segment(void *, int, _Out_ BaseRTTranscribeSegment *)"
+    ),
     baseRT_transcribe: k.func(
       "const char *baseRT_transcribe(void *, const char *, const char *, _Out_ BaseRTTranscribeStats *)"
     ),
@@ -854,12 +913,17 @@ export class BaseRTModel {
 
   prefill(tokens: number[] | Uint32Array): number {
     const arr = tokens instanceof Uint32Array ? tokens : Uint32Array.from(tokens);
+    // baseRT_prefill returns the first generated token (argmax of prefill
+    // logits) with no 0-sentinel; token id 0 is a valid token, so it must not
+    // be treated as an error.
     return this._l.baseRT_prefill(this.handle, arr, arr.length);
   }
 
   prefillImage(tokens: number[] | Uint32Array, imagePath: string): number {
     const arr = tokens instanceof Uint32Array ? tokens : Uint32Array.from(tokens);
-    return this._l.baseRT_prefill_image(this.handle, arr, arr.length, imagePath);
+    const t = this._l.baseRT_prefill_image(this.handle, arr, arr.length, imagePath);
+    if (t === 0) throw new Error(`prefillImage failed: ${this._l.baseRT_get_error() || "?"}`);
+    return t;
   }
 
   imageNumTokens(imagePath: string): number {
@@ -868,7 +932,9 @@ export class BaseRTModel {
 
   prefillAudio(tokens: number[] | Uint32Array, pcm: Float32Array): number {
     const arr = tokens instanceof Uint32Array ? tokens : Uint32Array.from(tokens);
-    return this._l.baseRT_prefill_audio(this.handle, arr, arr.length, pcm, pcm.length);
+    const t = this._l.baseRT_prefill_audio(this.handle, arr, arr.length, pcm, pcm.length);
+    if (t === 0) throw new Error(`prefillAudio failed: ${this._l.baseRT_get_error() || "?"}`);
+    return t;
   }
 
   audioNumTokens(nSamples: number): number {
@@ -876,6 +942,8 @@ export class BaseRTModel {
   }
 
   decodeStep(tokenId: number, position: number): number {
+    // baseRT_decode_step returns the sampled token ID with no 0-sentinel;
+    // token id 0 is a valid token and must not be treated as an error.
     return this._l.baseRT_decode_step(this.handle, tokenId, position);
   }
 
@@ -888,7 +956,8 @@ export class BaseRTModel {
       count,
       buf
     );
-    return Array.from(buf.subarray(0, Math.max(0, n)));
+    if (n < 0) throw new Error(`chainDecode failed: ${this._l.baseRT_get_error() || "?"}`);
+    return Array.from(buf.subarray(0, n));
   }
 
   reset(): void {
@@ -938,6 +1007,63 @@ export class BaseRTModel {
     this._l.baseRT_set_timestamps(this.handle, enabled);
   }
 
+  /** Set the Whisper task: "transcribe" (default) or "translate". */
+  setTask(task: string): void {
+    if (!this._l.baseRT_set_task(this.handle, task)) {
+      throw new Error(
+        `setTask failed: ${this._l.baseRT_get_error() || "unknown error"}`
+      );
+    }
+  }
+
+  /** Set an initial prompt to bias Whisper decoding (null clears it). */
+  setInitialPrompt(text: string | null): void {
+    this._l.baseRT_set_initial_prompt(this.handle, text);
+  }
+
+  /** Condition each 30s window on previous decoded text (default true). */
+  setConditionOnPreviousText(enabled: boolean): void {
+    this._l.baseRT_set_condition_on_previous_text(this.handle, enabled);
+  }
+
+  /** Language code of the last transcription (detected or requested). */
+  transcribeLanguage(): string {
+    return this._l.baseRT_transcribe_language(this.handle) || "";
+  }
+
+  /**
+   * Duration of the last transcription's source audio in milliseconds (the
+   * OpenAI verbose_json `duration` field is this value in fractional
+   * seconds). 0 if no transcription has run.
+   */
+  transcribeAudioDurationMs(): number {
+    return this._l.baseRT_transcribe_audio_duration_ms(this.handle);
+  }
+
+  /**
+   * Per-segment metadata for the last transcription (verbose_json surface).
+   * Empty if no transcription has run. Segment text is copied out, so the
+   * returned array stays valid after later transcriptions.
+   */
+  transcribeSegments(): TranscribeSegment[] {
+    const n = this._l.baseRT_transcribe_segment_count(this.handle);
+    const out: TranscribeSegment[] = [];
+    for (let i = 0; i < n; i++) {
+      const seg: Record<string, unknown> = {};
+      if (!this._l.baseRT_transcribe_segment(this.handle, i, seg)) break;
+      out.push({
+        startMs: seg.start_ms as number,
+        endMs: seg.end_ms as number,
+        text: (seg.text as string) || "",
+        avgLogprob: seg.avg_logprob as number,
+        noSpeechProb: seg.no_speech_prob as number,
+        compressionRatio: seg.compression_ratio as number,
+        temperature: seg.temperature as number,
+      });
+    }
+    return out;
+  }
+
   transcribe(wavPath: string, language?: string): TranscribeResult {
     const stats: Record<string, number> = {};
     const text = this._l.baseRT_transcribe(
@@ -946,7 +1072,9 @@ export class BaseRTModel {
       language ?? null,
       stats
     );
-    return { text: text || "", stats: toTranscribeStats(stats) };
+    if (text == null)
+      throw new Error(`transcribe failed: ${this._l.baseRT_get_error() || "?"}`);
+    return { text, stats: toTranscribeStats(stats) };
   }
 
   transcribePcm(samples: Float32Array, language?: string): TranscribeResult {
@@ -958,7 +1086,9 @@ export class BaseRTModel {
       language ?? null,
       stats
     );
-    return { text: text || "", stats: toTranscribeStats(stats) };
+    if (text == null)
+      throw new Error(`transcribePcm failed: ${this._l.baseRT_get_error() || "?"}`);
+    return { text, stats: toTranscribeStats(stats) };
   }
 
   transcribeStream(
@@ -1030,6 +1160,7 @@ export const __internal = {
   SamplingConfigC,
   GenerationStatsC,
   TranscribeStatsC,
+  TranscribeSegmentC,
   toSamplingC,
   toModelConfig,
 };

--- a/bindings/python/baseRT/__init__.py
+++ b/bindings/python/baseRT/__init__.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 # ---------------------------------------------------------------------------
 # Library loading
@@ -248,6 +248,20 @@ class BaseRTTranscribeStats(ctypes.Structure):
     ]
 
 
+class BaseRTTranscribeSegment(ctypes.Structure):
+    """Mirror of the C BaseRTTranscribeSegment struct."""
+
+    _fields_ = [
+        ("start_ms", ctypes.c_int),
+        ("end_ms", ctypes.c_int),
+        ("text", ctypes.c_char_p),
+        ("avg_logprob", ctypes.c_float),
+        ("no_speech_prob", ctypes.c_float),
+        ("compression_ratio", ctypes.c_float),
+        ("temperature", ctypes.c_float),
+    ]
+
+
 # Callback type: bool (*)(uint32_t token_id, const char *text, void *user_data)
 BASERT_TOKEN_CALLBACK = ctypes.CFUNCTYPE(
     ctypes.c_bool, ctypes.c_uint32, ctypes.c_char_p, ctypes.c_void_p
@@ -357,6 +371,36 @@ class TranscribeStats:
             encode_ms=c.encode_ms,
             decode_ms=c.decode_ms,
             total_ms=c.total_ms,
+        )
+
+
+@dataclass
+class TranscribeSegment:
+    """One segment of the last transcription (verbose_json surface).
+
+    avg_logprob / no_speech_prob / compression_ratio / temperature are
+    window-level values applied to every segment decoded in that 30 s
+    window (the engine's documented approximation).
+    """
+
+    start_ms: int
+    end_ms: int
+    text: str
+    avg_logprob: float
+    no_speech_prob: float
+    compression_ratio: float
+    temperature: float
+
+    @staticmethod
+    def _from_c(c: BaseRTTranscribeSegment) -> "TranscribeSegment":
+        return TranscribeSegment(
+            start_ms=c.start_ms,
+            end_ms=c.end_ms,
+            text=c.text.decode("utf-8") if c.text else "",
+            avg_logprob=c.avg_logprob,
+            no_speech_prob=c.no_speech_prob,
+            compression_ratio=c.compression_ratio,
+            temperature=c.temperature,
         )
 
 
@@ -525,6 +569,31 @@ def _setup_signatures(lib: ctypes.CDLL) -> None:
     lib.baseRT_set_timestamps.argtypes = [ctypes.c_void_p, ctypes.c_bool]
     lib.baseRT_set_timestamps.restype = None
 
+    lib.baseRT_set_task.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+    lib.baseRT_set_task.restype = ctypes.c_bool
+
+    lib.baseRT_set_initial_prompt.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+    lib.baseRT_set_initial_prompt.restype = None
+
+    lib.baseRT_set_condition_on_previous_text.argtypes = [ctypes.c_void_p, ctypes.c_bool]
+    lib.baseRT_set_condition_on_previous_text.restype = None
+
+    lib.baseRT_transcribe_language.argtypes = [ctypes.c_void_p]
+    lib.baseRT_transcribe_language.restype = ctypes.c_char_p
+
+    lib.baseRT_transcribe_audio_duration_ms.argtypes = [ctypes.c_void_p]
+    lib.baseRT_transcribe_audio_duration_ms.restype = ctypes.c_int
+
+    lib.baseRT_transcribe_segment_count.argtypes = [ctypes.c_void_p]
+    lib.baseRT_transcribe_segment_count.restype = ctypes.c_int
+
+    lib.baseRT_transcribe_segment.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_int,
+        ctypes.POINTER(BaseRTTranscribeSegment),
+    ]
+    lib.baseRT_transcribe_segment.restype = ctypes.c_bool
+
     lib.baseRT_is_whisper.argtypes = [ctypes.c_void_p]
     lib.baseRT_is_whisper.restype = ctypes.c_bool
 
@@ -626,6 +695,104 @@ def _check_model(handle: ctypes.c_void_p) -> None:
         raise BaseRTError(f"Failed to load model: {err}")
 
 
+class _ReentrancyGuardedLock:
+    """Per-handle serialization lock plus a thread-local re-entrancy guard.
+
+    Wraps the non-reentrant per-handle ``threading.Lock`` that serializes every
+    native call touching the single non-thread-safe C handle. On top of that it
+    adds a per-instance, thread-local depth counter so a *direct* (non-stream)
+    generate/transcribe native call -- which invokes the user's Python callback
+    SYNCHRONOUSLY while this lock is held -- cannot self-deadlock:
+
+    * The direct-path callback trampoline calls :meth:`enter_callback` right
+      before running the user callback and :meth:`exit_callback` in a ``finally``
+      right after. Between those, this thread's marker is > 0.
+    * :meth:`acquire` (used by every ``with self._handle_lock`` guarded method)
+      checks the marker BEFORE touching the underlying lock. If the marker is
+      > 0 -- i.e. the caller is a user callback re-entering a handle method on
+      the SAME thread while the native call still holds the lock -- it raises
+      :class:`BaseRTError` immediately instead of blocking forever on the
+      non-reentrant lock. This turns a self-deadlock into a clear exception and
+      never issues a nested native call, so generation is not corrupted.
+    * Unrelated threads (marker 0) acquire and block-and-wait exactly as before,
+      so the stream-vs-reuse serialization is unchanged. The stream worker's
+      token callback only enqueues text (never :meth:`enter_callback`, never a
+      handle method), so its thread's marker stays 0 and that path is unaffected.
+
+    The marker is per instance (its own :class:`threading.local`), so being
+    inside model A's callback does not reject a concurrent call to model B.
+
+    .. warning::
+
+        The one case the thread-local guard cannot rescue is a callback that
+        synchronously hands work to a *different* thread which then calls this
+        model -- e.g. ``on_token = lambda t: executor.submit(model.position).result()``
+        inside a direct :meth:`Model.generate`. That other thread's marker is 0,
+        so it does not raise; it blocks on the busy handle lock while the worker
+        thread (parked waiting on the other thread's result) still holds it, and
+        the two DEADLOCK. This is NOT eliminated and is NOT a defect: the model
+        is single-owner / non-thread-safe and the handle is exclusively busy for
+        the callback's duration, so it is a single-owner-contract violation -- do
+        NOT call model APIs from a *different* thread that a callback is
+        synchronously waiting on. Distinguishing this from an unrelated concurrent
+        call is impossible without a model-wide flag, which would wrongly reject
+        legitimate concurrent callers (the reason the guard is thread-local, not a
+        coarse flag). The supported reentry case -- a same-thread call from within
+        the callback -- raises :class:`BaseRTError` cleanly instead.
+    """
+
+    _REENTRY_MSG = (
+        "Cannot call a model API from within a generation callback "
+        "(the native handle is busy for the callback's duration)"
+    )
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._depth = threading.local()
+
+    def _get_depth(self) -> int:
+        return getattr(self._depth, "value", 0)
+
+    def is_reentrant(self) -> bool:
+        """True if THIS thread is currently inside a direct-path user callback.
+
+        Lets a lifecycle method (e.g. :meth:`Model.close`) detect a callback-
+        initiated, same-thread re-entry BEFORE it touches the underlying lock --
+        so it can reject the call up front, before mutating any state, instead of
+        only discovering the re-entry when :meth:`acquire` would deadlock.
+        """
+        return self._get_depth() > 0
+
+    # Backwards/alternate spelling for callers that prefer the intent name.
+    in_callback = is_reentrant
+
+    def enter_callback(self) -> None:
+        """Mark this thread as running inside a direct-path user callback."""
+        self._depth.value = self._get_depth() + 1
+
+    def exit_callback(self) -> None:
+        """Balance :meth:`enter_callback`; always call from a ``finally``."""
+        self._depth.value = self._get_depth() - 1
+
+    def acquire(self, *args: Any, **kwargs: Any) -> bool:
+        # Guard BEFORE acquiring: if this thread is inside a direct-path user
+        # callback, the native call already holds the lock on this same thread,
+        # so acquiring the non-reentrant lock would deadlock. Fail loudly.
+        if self._get_depth() > 0:
+            raise BaseRTError(self._REENTRY_MSG)
+        return self._lock.acquire(*args, **kwargs)
+
+    def release(self) -> None:
+        self._lock.release()
+
+    def __enter__(self) -> "_ReentrancyGuardedLock":
+        self.acquire()
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.release()
+
+
 # ---------------------------------------------------------------------------
 # Model class
 # ---------------------------------------------------------------------------
@@ -647,6 +814,51 @@ class Model:
         max_context: int = 0,
     ) -> None:
         self._lib = _get_lib()
+        # In-flight stream() workers as (cancel_event, thread, done_event)
+        # triples, guarded by _streams_lock so close() can cancel them and prove
+        # each has actually left its native baseRT_generate call before freeing
+        # the C handle. done_event is the authoritative "native call returned,
+        # safe to free" signal: the worker sets it ONLY in _run's finally, after
+        # baseRT_generate has truly returned. close() WAITS on it rather than
+        # trusting thread.join(), which a KeyboardInterrupt can make return
+        # spuriously (Thread marked stopped while the native thread still runs).
+        self._streams: List[
+            Tuple[threading.Event, threading.Thread, threading.Event]
+        ] = []
+        self._streams_lock = threading.Lock()
+        # Per-handle lock serializing every native call that touches the single
+        # non-thread-safe C handle (baseRT_generate, prefill, decode, encode,
+        # transcribe, embed, info accessors, ...). Mirrors the Swift binding's
+        # handleLock. It is only ever held around the actual C call (never a
+        # whole method body), so no guarded method nests a second acquire, and
+        # the stream worker's token callback merely enqueues tokens -- it never
+        # calls a handle method -- so generation cannot re-enter it. Crucially,
+        # an abandoned-but-still-running stream worker holds this lock for its
+        # whole baseRT_generate, so any reuse of the handle BLOCKS here until
+        # that native call returns, preventing overlapping calls on the single-
+        # owner handle. close() does NOT take this lock while waiting on a worker
+        # (it waits on done_event instead), so cancel+wait cannot deadlock
+        # against a worker that needs the lock.
+        #
+        # It is a _ReentrancyGuardedLock, not a plain Lock: a DIRECT (non-stream)
+        # generate/transcribe holds it while running the user's callback
+        # synchronously. If that callback calls a handle method on the SAME
+        # thread, the non-reentrant lock would self-deadlock; the guard raises
+        # BaseRTError instead. Mirrors the Swift binding's re-entrancy handling.
+        self._handle_lock = _ReentrancyGuardedLock()
+        # Set under _streams_lock in close(); stream() refuses to register new
+        # workers once this is set so close() can never miss (or race) one.
+        self._closing = False
+        # Handle awaiting the native free. close() moves the live handle here
+        # (clearing self._handle) and only clears it once baseRT_free_model has
+        # actually run. Because the ONLY reference to a not-yet-freed handle then
+        # lives on the instance -- never a stack local -- an interrupted close()
+        # (e.g. KeyboardInterrupt mid worker-join) leaves the handle reachable
+        # for a later close()/__del__ to resume and free exactly once.
+        self._pending_free_handle: Optional[ctypes.c_void_p] = None
+        # Default before load so a failed load still leaves a well-formed handle
+        # attribute for close()/__del__ to inspect.
+        self._handle: Optional[ctypes.c_void_p] = None
         mp = model_path.encode("utf-8")
         ml = kernel_library_path.encode("utf-8") if kernel_library_path else None
         self._handle = self._lib.baseRT_load_model(mp, ml, max_context)
@@ -661,52 +873,217 @@ class Model:
         self.close()
 
     def close(self) -> None:
-        """Release all GPU resources."""
-        if getattr(self, "_handle", None):
-            self._lib.baseRT_free_model(self._handle)
-            self._handle = None
+        """Release all GPU resources.
+
+        Cancels any in-flight :meth:`stream` workers and waits for each worker's
+        ``done_event`` -- set only after its ``baseRT_generate`` call has truly
+        returned -- so the C handle is never freed underneath a live native call.
+        The event, not ``thread.join()``, is the authoritative proof a worker has
+        stopped: on CPython a ``KeyboardInterrupt`` during ``join()`` can leave
+        the ``Thread`` marked stopped while its native thread is still inside
+        ``baseRT_generate``, so a resumed ``join()`` would return spuriously and
+        we would free under a live call. ``Event.wait()`` cannot: the event is
+        set only by the worker, after the native call returns.
+
+        Shutdown is resumable and frees the native handle exactly once, even if
+        an earlier ``close()`` was interrupted (e.g. ``KeyboardInterrupt`` while
+        waiting on a worker's ``done_event``). The first caller flips ``_closing``
+        and moves the live handle onto ``self._pending_free_handle`` (clearing
+        ``self._handle``); that instance attribute -- never a stack local --
+        stays the sole reference to the not-yet-freed handle. So if this call
+        unwinds mid-wait, a later ``close()`` / ``__del__`` re-enters, re-waits on
+        the (idempotent, already-set-or-still-running) ``done_event``s, and only
+        then completes the free. Because the wait blocks on an unset event, a
+        resumed ``close()`` (a) cannot free while any worker's ``done_event`` is
+        unset, and (b) eventually proceeds once every event is set. The final
+        claim+free runs atomically under the lock: whichever caller finds the
+        handle still pending clears it and frees once, and every other concurrent
+        or resumed caller then observes ``None`` and returns -- so there is never
+        a double free, and the handle is never freed while a worker is inside a
+        C call.
+        """
+        lock = getattr(self, "_streams_lock", None)
+        if lock is None:
+            return  # __init__ failed before the lock existed; nothing to free
+        # Reject a callback-initiated shutdown BEFORE mutating ANY lifecycle
+        # state. A direct (non-stream) generate/transcribe runs the user callback
+        # synchronously while _handle_lock is held on THIS thread; if that
+        # callback calls close(), the old code only tripped the re-entrancy guard
+        # once close() reached `with self._handle_lock` far below -- by which time
+        # it had already flipped _closing and moved/cleared self._handle, leaving
+        # the model half-closed even though the call is rejected. Check the
+        # thread-local depth at the TOP, before _closing is set and before the
+        # handle is snapshotted/cleared, so a rejected reentrant close() leaves
+        # the model fully intact and still usable. Unrelated threads (depth 0) and
+        # the normal non-reentrant close path are unaffected.
+        handle_lock = getattr(self, "_handle_lock", None)
+        if handle_lock is not None and handle_lock.is_reentrant():
+            raise BaseRTError(
+                "Cannot close a model from within a generation callback "
+                "(the native handle is busy for the callback's duration)"
+            )
+        with lock:
+            if not self._closing:
+                self._closing = True
+                # Move the live handle onto the instance so the only reference
+                # to it survives an interrupted join and a later close() can
+                # resume freeing it.
+                self._pending_free_handle = self._handle
+                self._handle = None
+            # On first entry this is the handle just moved; on re-entry (resumed
+            # after an interrupt) or for a concurrent caller it is whatever is
+            # still pending. None means already freed or never allocated.
+            handle = self._pending_free_handle
+            if handle is None:
+                return
+            streams = list(self._streams)
+        # Cancel + wait outside the lock so each worker's generator can
+        # re-acquire it to deregister itself; new stream() calls are already
+        # refused by _closing. We set the cancel flag so the native token loop
+        # stops promptly (returning False from the callback) and then WAIT ON
+        # done_event -- NOT thread.join(). done_event is set only in the worker's
+        # finally, after baseRT_generate has actually returned, so waiting on it
+        # proves the native call is no longer running. thread.join() is not
+        # trusted here: a KeyboardInterrupt during a prior join() can leave the
+        # Thread object marked stopped while its native thread is still inside
+        # baseRT_generate, so a resumed join() would return at once and we would
+        # free the handle underneath a live call. Waiting on done_event is
+        # idempotent (an already-set event returns instantly) and safe to resume:
+        # if this wait is interrupted, _pending_free_handle is still set, so a
+        # later close()/__del__ retries and only frees once every done_event is
+        # set. Cancelling first guarantees the wait cannot block forever.
+        for cancel, thread, done in streams:
+            cancel.set()
+            done.wait()
+        # Claim and free atomically under BOTH locks. Clearing the pending
+        # handle and calling baseRT_free_model in the same critical section
+        # leaves no interruptible Python-level gap between them, and guarantees a
+        # single native free across concurrent/resumed callers.
+        #
+        # We take _handle_lock (not just _streams_lock) around the free so we
+        # never free underneath an in-flight GUARDED non-worker call. A method
+        # like reset() that acquired _handle_lock BEFORE close() cleared
+        # self._handle read the (still valid) handle and is running native on
+        # it; acquiring _handle_lock here BLOCKS until that call releases, then
+        # frees. A method that only acquires _handle_lock AFTER this point sees
+        # self._handle is None via _ensure_open and raises instead of using the
+        # freed handle. Both orderings are therefore safe.
+        #
+        # No deadlock: the lock order is always _streams_lock -> _handle_lock
+        # (stream() holds _streams_lock and then acquires _handle_lock via
+        # encode(); here close() does the same), and nothing ever acquires them
+        # in the reverse order -- guarded methods take only _handle_lock, and the
+        # stream worker releases _handle_lock before it touches _streams_lock.
+        # Workers already released _handle_lock before setting the done_events we
+        # waited on above, so none of them holds it now. Blocking on _handle_lock
+        # while _pending_free_handle is still set keeps the free resumable: an
+        # interrupt here leaves the handle reachable for a later close()/__del__.
+        with lock:
+            handle = self._pending_free_handle
+            if handle is None:
+                return  # another caller already claimed and freed it
+            with self._handle_lock:
+                self._pending_free_handle = None
+                self._lib.baseRT_free_model(handle)
 
     def __del__(self) -> None:
-        self.close()
+        try:
+            self.close()
+        except Exception:
+            pass  # never raise from a finalizer
+
+    def _ensure_open(self) -> None:
+        """Raise if the handle has been closed/freed.
+
+        MUST be called while holding ``_handle_lock``, as the very first thing
+        inside every guarded method's ``with self._handle_lock`` block, BEFORE
+        the native call. ``close()`` clears ``self._handle`` (and sets
+        ``_closing``) under ``_streams_lock``, then frees the handle under
+        ``_handle_lock``. So a method that was queued on ``_handle_lock`` behind
+        an in-flight worker/call while ``close()`` ran will, once it finally
+        acquires the lock, observe ``self._handle is None`` here and fail
+        cleanly instead of issuing a native call on a freed handle. Reading
+        ``self._handle`` under the GIL is atomic, so this check is race-free.
+        """
+        if self._closing or self._handle is None:
+            raise BaseRTError("model is closed")
 
     # -- model info ----------------------------------------------------------
 
     @property
     def config(self) -> ModelConfig:
         """Return the model configuration."""
-        c = self._lib.baseRT_get_config(self._handle)
+        with self._handle_lock:
+            self._ensure_open()
+            c = self._lib.baseRT_get_config(self._handle)
         return ModelConfig._from_c(c)
 
     @property
     def memory_bytes(self) -> int:
         """Total GPU memory used by the model in bytes."""
-        return self._lib.baseRT_model_memory(self._handle)
+        with self._handle_lock:
+            self._ensure_open()
+            return self._lib.baseRT_model_memory(self._handle)
 
     @property
     def is_whisper(self) -> bool:
         """True if this is a Whisper (audio) model."""
-        return bool(self._lib.baseRT_is_whisper(self._handle))
+        with self._handle_lock:
+            self._ensure_open()
+            return bool(self._lib.baseRT_is_whisper(self._handle))
 
     @property
     def position(self) -> int:
         """Current KV cache position (number of tokens processed)."""
-        return self._lib.baseRT_get_position(self._handle)
+        with self._handle_lock:
+            self._ensure_open()
+            return self._lib.baseRT_get_position(self._handle)
 
     # -- tokenization --------------------------------------------------------
 
     def encode(self, text: str, max_tokens: int = 8192) -> List[int]:
-        """Encode text into token IDs."""
+        """Encode text into token IDs.
+
+        Public, lifecycle-checked entry point: acquires ``_handle_lock``,
+        validates the handle via :meth:`_ensure_open`, and only then issues the
+        native call. There is deliberately NO public ``handle`` parameter -- an
+        external caller must never be able to inject a foreign or already-freed
+        handle (which would bypass the close/free lifecycle and cause a
+        use-after-free). The captured-handle fast path lives in the private
+        :meth:`_encode_with_handle` and is only reachable from internal code that
+        has already validated the handle under ``_handle_lock``.
+        """
+        with self._handle_lock:
+            self._ensure_open()
+            handle = self._handle
+            return self._encode_with_handle(text, max_tokens, handle)
+
+    def _encode_with_handle(
+        self,
+        text: str,
+        max_tokens: int,
+        handle: ctypes.c_void_p,
+    ) -> List[int]:
+        """Run ``baseRT_encode`` on an already-validated, lock-held handle.
+
+        PRIVATE: the caller MUST already hold ``_handle_lock`` and must have
+        validated ``handle`` (either via :meth:`_ensure_open` or by capturing a
+        still-live handle under a lock that blocks ``close()``). This method does
+        NOT call :meth:`_ensure_open`, so it must never be exposed on the public
+        surface: doing so would let an external caller pass a stale/foreign
+        handle and issue a native call on freed memory.
+        """
         buf = (ctypes.c_uint32 * max_tokens)()
-        n = self._lib.baseRT_encode(
-            self._handle, text.encode("utf-8"), buf, max_tokens
-        )
+        n = self._lib.baseRT_encode(handle, text.encode("utf-8"), buf, max_tokens)
         if n < 0:
             raise BaseRTError(get_error() or "encode failed")
         return list(buf[:n])
 
     def decode_token(self, token_id: int) -> str:
         """Decode a single token ID to its text representation."""
-        s = self._lib.baseRT_decode_token(self._handle, token_id)
+        with self._handle_lock:
+            self._ensure_open()
+            s = self._lib.baseRT_decode_token(self._handle, token_id)
         return s.decode("utf-8") if s else ""
 
     # -- sampling config helper ----------------------------------------------
@@ -779,22 +1156,57 @@ class Model:
 
         Returns:
             GenerationStats with timing information.
+
+        Warning:
+            ``callback`` runs synchronously while the native handle is busy and
+            ``_handle_lock`` is held on this thread. Do NOT call other methods of
+            this model from within it: a same-thread call raises
+            :class:`BaseRTError` (the thread-local re-entrancy guard). Delegating
+            synchronously to a DIFFERENT thread that then calls this model can
+            DEADLOCK -- that thread blocks on the busy handle while this one waits
+            on it. That is a single-owner-contract violation, not a defect, and is
+            unsupported.
         """
         tokens = self._to_token_array(prompt)
         sampling, _anchor = self._make_sampling(temperature, top_k, top_p, min_p, repeat_penalty)
 
+        # Stash for any exception the user callback (or the re-entrancy guard)
+        # raises. ctypes CANNOT propagate a Python exception across the C
+        # boundary: it prints the traceback and returns 0/None (False) to C,
+        # silently swallowing it while generation may continue. So the trampoline
+        # catches EVERYTHING, stashes it, returns the STOP value (False) so
+        # baseRT_generate halts promptly, and we re-raise below -- OUTSIDE the
+        # ctypes boundary. Mirrors the Rust binding's catch_unwind trampoline.
+        cb_exc: List[BaseException] = []
+
         if callback is not None:
             @BASERT_TOKEN_CALLBACK
             def _cb(tid: int, text: bytes, _ud: ctypes.c_void_p) -> bool:
-                return callback(tid, text.decode("utf-8") if text else "")
+                # This runs synchronously inside baseRT_generate while
+                # _handle_lock is held on this thread. Mark the thread as
+                # in-callback so any handle method the user callback calls
+                # raises instead of self-deadlocking on the non-reentrant lock;
+                # always balanced by the finally so the marker never leaks.
+                self._handle_lock.enter_callback()
+                try:
+                    return callback(tid, text.decode("utf-8") if text else "")
+                except BaseException as exc:
+                    cb_exc.append(exc)
+                    return False  # STOP: never let the exception cross ctypes
+                finally:
+                    self._handle_lock.exit_callback()
 
             cb = _cb
         else:
             cb = BASERT_TOKEN_CALLBACK(0)  # NULL
 
-        stats_c = self._lib.baseRT_generate(
-            self._handle, tokens, len(tokens), max_tokens, sampling, cb, None
-        )
+        with self._handle_lock:
+            self._ensure_open()
+            stats_c = self._lib.baseRT_generate(
+                self._handle, tokens, len(tokens), max_tokens, sampling, cb, None
+            )
+        if cb_exc:
+            raise cb_exc[0]  # re-raise outside the ctypes boundary
         return GenerationStats._from_c(stats_c)
 
     def generate_continue(
@@ -808,22 +1220,49 @@ class Model:
         repeat_penalty: float = 1.0,
         callback: Optional[Callable[[int, str], bool]] = None,
     ) -> GenerationStats:
-        """Continue generation from the current KV cache state (multi-turn)."""
+        """Continue generation from the current KV cache state (multi-turn).
+
+        Warning:
+            ``callback`` runs synchronously while the native handle is busy. Do
+            NOT call other methods of this model from within it: a same-thread
+            call raises :class:`BaseRTError`, and delegating synchronously to a
+            DIFFERENT thread that then calls this model can DEADLOCK on the busy
+            handle. That is a single-owner-contract violation, not a defect. See
+            :meth:`generate`.
+        """
         tokens = self._to_token_array(new_tokens)
         sampling, _anchor = self._make_sampling(temperature, top_k, top_p, min_p, repeat_penalty)
+
+        # See generate(): stash any callback/guard exception, STOP native
+        # generation (return False), and re-raise outside the ctypes boundary.
+        cb_exc: List[BaseException] = []
 
         if callback is not None:
             @BASERT_TOKEN_CALLBACK
             def _cb(tid: int, text: bytes, _ud: ctypes.c_void_p) -> bool:
-                return callback(tid, text.decode("utf-8") if text else "")
+                # Runs synchronously inside baseRT_generate_continue while
+                # _handle_lock is held on this thread -- mark in-callback so a
+                # re-entrant handle method raises instead of self-deadlocking.
+                self._handle_lock.enter_callback()
+                try:
+                    return callback(tid, text.decode("utf-8") if text else "")
+                except BaseException as exc:
+                    cb_exc.append(exc)
+                    return False  # STOP: never let the exception cross ctypes
+                finally:
+                    self._handle_lock.exit_callback()
 
             cb = _cb
         else:
             cb = BASERT_TOKEN_CALLBACK(0)
 
-        stats_c = self._lib.baseRT_generate_continue(
-            self._handle, tokens, len(tokens), max_tokens, sampling, cb, None
-        )
+        with self._handle_lock:
+            self._ensure_open()
+            stats_c = self._lib.baseRT_generate_continue(
+                self._handle, tokens, len(tokens), max_tokens, sampling, cb, None
+            )
+        if cb_exc:
+            raise cb_exc[0]  # re-raise outside the ctypes boundary
         return GenerationStats._from_c(stats_c)
 
     def stream(
@@ -848,35 +1287,143 @@ class Model:
             for text in gen:
                 print(text, end="", flush=True)
         """
-        q: queue.Queue[Optional[str]] = queue.Queue()
+        # Reject a callback-initiated stream start BEFORE registering a worker or
+        # touching ANY lifecycle state (_streams / _closing / the handle). A
+        # direct (non-stream) generate/transcribe runs the user callback
+        # synchronously while _handle_lock is held on THIS thread; if that
+        # callback starts a new stream, the worker's _handle_lock.acquire() (or
+        # this method's registration) could deadlock or mutate lifecycle state
+        # against a concurrent close() before the reentrancy guard would fire.
+        # Trip the thread-local re-entrancy marker up front -- consistent with
+        # how close() was hardened -- so a reentrant start raises cleanly with no
+        # state change. Unrelated threads (depth 0) are unaffected.
+        if self._handle_lock.is_reentrant():
+            raise BaseRTError(
+                "Cannot start a stream from within a generation callback "
+                "(the native handle is busy for the callback's duration)"
+            )
+        q: queue.Queue[Union[str, BaseException, None]] = queue.Queue()
         stats_holder: List[Optional[GenerationStats]] = [None]
+        cancel = threading.Event()
+        # Set ONLY after baseRT_generate has truly returned (in _run's finally).
+        # This is the authoritative "native call has returned, safe to free"
+        # signal close() waits on -- robust to a thread.join() that a
+        # KeyboardInterrupt made return spuriously.
+        done = threading.Event()
 
-        def _run() -> None:
+        def _run(
+            handle: ctypes.c_void_p,
+            tokens: ctypes.Array[ctypes.c_uint32],
+        ) -> None:
             @BASERT_TOKEN_CALLBACK
             def _cb(tid: int, text: bytes, _ud: ctypes.c_void_p) -> bool:
                 q.put(text.decode("utf-8") if text else "")
-                return True
+                # Returning False stops generation (consumer gone or close()).
+                return not cancel.is_set()
 
-            tokens = self._to_token_array(prompt)
-            sampling, _anchor = self._make_sampling(
-                temperature, top_k, top_p, min_p, repeat_penalty
-            )
-            stats_c = self._lib.baseRT_generate(
-                self._handle, tokens, len(tokens), max_tokens, sampling, _cb, None
-            )
-            stats_holder[0] = GenerationStats._from_c(stats_c)
-            q.put(None)  # sentinel
+            try:
+                sampling, _anchor = self._make_sampling(
+                    temperature, top_k, top_p, min_p, repeat_penalty
+                )
+                # Use the handle captured under _streams_lock at registration
+                # time, not self._handle: close() clears self._handle the instant
+                # it takes ownership, but waits on done_event before freeing, so
+                # the captured handle stays valid for the lifetime of this call.
+                #
+                # Hold _handle_lock for the ENTIRE native generate. If this
+                # generator is abandoned (caller `break`s out of the loop and
+                # keeps a reference, so Python does not auto-close it), the
+                # worker keeps running until it hits max_tokens; while it does,
+                # this lock is held, so any reuse of the model on another thread
+                # blocks in its own `with self._handle_lock` until this native
+                # call returns -- no overlapping baseRT_generate on the single
+                # non-thread-safe handle, no KV/GPU corruption. Released in the
+                # `finally` here BEFORE done.set() below, so close()'s wait on
+                # done_event never observes a set event while the lock (and thus
+                # the native call) is still live.
+                self._handle_lock.acquire()
+                try:
+                    # Re-check cancellation/open state INSIDE the locked window,
+                    # right before the native call. This worker may have been
+                    # QUEUED on _handle_lock behind another handle call; while it
+                    # waited, close() or the consumer could have cancelled it
+                    # (cancel.set()) and/or close() could have cleared the handle.
+                    # If so, skip baseRT_generate entirely rather than burn GPU
+                    # time (prompt prefill + generation to max_tokens) on an
+                    # already-cancelled stream and delay later calls. Mirrors the
+                    # Swift skip-on-cancel inside the locked window. The outer
+                    # finally still fires the sentinel and done event on this
+                    # early-out path, so close()/consumers never hang.
+                    if cancel.is_set() or self._closing or self._handle is None:
+                        return
+                    stats_c = self._lib.baseRT_generate(
+                        handle, tokens, len(tokens), max_tokens, sampling, _cb, None
+                    )
+                finally:
+                    self._handle_lock.release()
+                stats_holder[0] = GenerationStats._from_c(stats_c)
+            except BaseException as exc:  # re-raised on the consumer side
+                q.put(exc)
+            finally:
+                q.put(None)  # sentinel: always unblock the consumer
+                # baseRT_generate has now returned (normally, via cancel, or by
+                # raising) and _handle_lock has been released: the native handle
+                # is no longer in use by this worker. Signal close() it is safe
+                # to free. Set LAST so the event never fires while the native
+                # call -- or the lock guarding it -- could still be live.
+                done.set()
 
-        t = threading.Thread(target=_run, daemon=True)
-        t.start()
+        with self._streams_lock:
+            # Register and start under the same lock close() uses, so close()
+            # never snapshots a half-registered worker: it either sees a
+            # started, joinable thread here, or refuses us via _closing below.
+            if self._closing:
+                raise BaseRTError("Model is closing; cannot start new stream")
+            # Capture the live handle under the lock: while _closing is unset,
+            # close() has not yet cleared self._handle, so this is guaranteed
+            # non-None and stays valid until close() joins this worker.
+            handle = self._handle
+            # Tokenize a string prompt HERE, on the calling thread, under the
+            # lock and against the captured handle -- never inside the worker
+            # against self._handle. Otherwise close() on another thread could
+            # null self._handle before the worker tokenizes, feeding a null
+            # handle into baseRT_encode and crashing. Doing it now means the
+            # worker only ever runs baseRT_generate on the captured handle.
+            #
+            # _to_token_array takes _handle_lock ONLY when it actually tokenizes
+            # a string (the sole native call); a pre-tokenized list prompt makes
+            # no native call and never touches _handle_lock, so a worker with a
+            # list prompt can still register while another handle call holds the
+            # lock. Lock order stays _streams_lock -> _handle_lock.
+            tokens = self._to_token_array(prompt, handle)
+            t = threading.Thread(target=_run, args=(handle, tokens), daemon=True)
+            entry = (cancel, t, done)
+            t.start()
+            self._streams.append(entry)
 
-        while True:
-            item = q.get()
-            if item is None:
-                break
-            yield item
-
-        t.join()
+        error: Optional[BaseException] = None
+        try:
+            while True:
+                item = q.get()
+                if item is None:
+                    break
+                if isinstance(item, BaseException):
+                    error = item
+                    continue  # sentinel follows immediately
+                yield item
+        finally:
+            # Consumer stopped (exhausted, closed early, or errored): signal
+            # the worker to halt generation and wait for it to leave the C
+            # call before returning. Wait on done_event -- set only after
+            # baseRT_generate has truly returned -- so we never deregister the
+            # entry while the native call could still be running.
+            cancel.set()
+            done.wait()
+            with self._streams_lock:
+                if entry in self._streams:
+                    self._streams.remove(entry)
+        if error is not None:
+            raise error
 
     def generate_text(
         self,
@@ -905,63 +1452,92 @@ class Model:
     def prefill(self, tokens: Union[str, List[int]]) -> int:
         """Run prefill, returning the first generated token ID."""
         arr = self._to_token_array(tokens)
-        return self._lib.baseRT_prefill(self._handle, arr, len(arr))
+        # baseRT_prefill returns the first generated token (argmax of prefill
+        # logits) with no 0-sentinel; token id 0 is a valid token, so do not
+        # treat it as an error. Errors surface via baseRT_get_error elsewhere.
+        with self._handle_lock:
+            self._ensure_open()
+            return self._lib.baseRT_prefill(self._handle, arr, len(arr))
 
     def prefill_image(self, tokens: Union[str, List[int]], image_path: str) -> int:
         """Multimodal prefill: run vision tower on image, splice features into
         the prompt at image_token_id positions, then run LLM prefill.
-        Returns the first generated token ID, or 0 on error."""
+        Returns the first generated token ID."""
         arr = self._to_token_array(tokens)
-        return self._lib.baseRT_prefill_image(
-            self._handle, arr, len(arr), image_path.encode("utf-8")
-        )
+        with self._handle_lock:
+            self._ensure_open()
+            tid = self._lib.baseRT_prefill_image(
+                self._handle, arr, len(arr), image_path.encode("utf-8")
+            )
+        if tid == 0:
+            raise BaseRTError(get_error() or "prefill_image failed")
+        return tid
 
     def image_num_tokens(self, image_path: str) -> int:
         """Return the number of image placeholder tokens the vision tower
         produces for the given image (depends on image dimensions)."""
-        return self._lib.baseRT_image_num_tokens(
-            self._handle, image_path.encode("utf-8")
-        )
+        with self._handle_lock:
+            self._ensure_open()
+            return self._lib.baseRT_image_num_tokens(
+                self._handle, image_path.encode("utf-8")
+            )
 
     def prefill_audio(
         self, tokens: Union[str, List[int]], pcm_samples: List[float]
     ) -> int:
         """Audio prefill: run Conformer encoder on PCM (16kHz mono float32),
         splice features into prompt at audio_token_id positions.
-        Returns first generated token ID, or 0 on error."""
+        Returns first generated token ID."""
         arr = self._to_token_array(tokens)
         pcm_arr = (ctypes.c_float * len(pcm_samples))(*pcm_samples)
-        return self._lib.baseRT_prefill_audio(
-            self._handle, arr, len(arr), pcm_arr, len(pcm_samples)
-        )
+        with self._handle_lock:
+            self._ensure_open()
+            tid = self._lib.baseRT_prefill_audio(
+                self._handle, arr, len(arr), pcm_arr, len(pcm_samples)
+            )
+        if tid == 0:
+            raise BaseRTError(get_error() or "prefill_audio failed")
+        return tid
 
     def audio_num_tokens(self, n_samples: int) -> int:
         """Return the number of audio placeholder tokens for n_samples of 16kHz PCM."""
-        return self._lib.baseRT_audio_num_tokens(self._handle, n_samples)
+        with self._handle_lock:
+            self._ensure_open()
+            return self._lib.baseRT_audio_num_tokens(self._handle, n_samples)
 
     def decode_step(self, token_id: int, position: int) -> int:
         """Run a single decode step, returning the next token ID."""
-        return self._lib.baseRT_decode_step(self._handle, token_id, position)
+        # baseRT_decode_step returns the sampled token ID with no 0-sentinel;
+        # token id 0 is a valid token and must not be treated as an error.
+        with self._handle_lock:
+            self._ensure_open()
+            return self._lib.baseRT_decode_step(self._handle, token_id, position)
 
     def chain_decode(
         self, first_token: int, start_position: int, count: int
     ) -> List[int]:
         """Chain decode multiple tokens in one GPU submission."""
         buf = (ctypes.c_uint32 * count)()
-        n = self._lib.baseRT_chain_decode(
-            self._handle, first_token, start_position, count, buf
-        )
+        with self._handle_lock:
+            self._ensure_open()
+            n = self._lib.baseRT_chain_decode(
+                self._handle, first_token, start_position, count, buf
+            )
         if n < 0:
             raise BaseRTError(get_error() or "chain_decode failed")
         return list(buf[:n])
 
     def reset(self) -> None:
         """Reset KV cache and internal state."""
-        self._lib.baseRT_reset(self._handle)
+        with self._handle_lock:
+            self._ensure_open()
+            self._lib.baseRT_reset(self._handle)
 
     def set_speculation(self, enabled: bool) -> None:
         """Enable or disable speculative decoding (n-gram prediction)."""
-        self._lib.baseRT_set_speculation(self._handle, enabled)
+        with self._handle_lock:
+            self._ensure_open()
+            self._lib.baseRT_set_speculation(self._handle, enabled)
 
     # -- whisper transcription -----------------------------------------------
 
@@ -977,9 +1553,11 @@ class Model:
         """
         stats_c = BaseRTTranscribeStats()
         lang = language.encode("utf-8") if language else None
-        result = self._lib.baseRT_transcribe(
-            self._handle, wav_path.encode("utf-8"), lang, ctypes.byref(stats_c)
-        )
+        with self._handle_lock:
+            self._ensure_open()
+            result = self._lib.baseRT_transcribe(
+                self._handle, wav_path.encode("utf-8"), lang, ctypes.byref(stats_c)
+            )
         if not result:
             raise BaseRTError(get_error() or "transcription failed")
         return result.decode("utf-8"), TranscribeStats._from_c(stats_c)
@@ -998,9 +1576,11 @@ class Model:
         arr = (ctypes.c_float * n)(*samples)
         stats_c = BaseRTTranscribeStats()
         lang = language.encode("utf-8") if language else None
-        result = self._lib.baseRT_transcribe_pcm(
-            self._handle, arr, n, lang, ctypes.byref(stats_c)
-        )
+        with self._handle_lock:
+            self._ensure_open()
+            result = self._lib.baseRT_transcribe_pcm(
+                self._handle, arr, n, lang, ctypes.byref(stats_c)
+            )
         if not result:
             raise BaseRTError(get_error() or "transcription failed")
         return result.decode("utf-8"), TranscribeStats._from_c(stats_c)
@@ -1021,22 +1601,50 @@ class Model:
 
         Returns:
             Tuple of (transcribed_text, stats).
+
+        Warning:
+            ``callback`` runs synchronously while the native handle is busy. Do
+            NOT call other methods of this model from within it: a same-thread
+            call raises :class:`BaseRTError`, and delegating synchronously to a
+            DIFFERENT thread that then calls this model can DEADLOCK on the busy
+            handle. That is a single-owner-contract violation, not a defect. See
+            :meth:`generate`.
         """
         stats_c = BaseRTTranscribeStats()
         lang = language.encode("utf-8") if language else None
 
+        # See generate(): the segment callback runs inside the native transcribe
+        # call via ctypes, which cannot propagate a Python exception across the C
+        # boundary. Stash it, STOP transcription (return False), re-raise after.
+        cb_exc: List[BaseException] = []
+
         if callback is not None:
             @BASERT_SEGMENT_CALLBACK
             def _cb(start_ms: int, end_ms: int, text: bytes, _ud: ctypes.c_void_p) -> bool:
-                return callback(start_ms, end_ms, text.decode("utf-8") if text else "")
+                # Runs synchronously inside the native transcribe call while
+                # _handle_lock is held on this thread -- mark in-callback so a
+                # re-entrant handle method raises instead of self-deadlocking;
+                # balanced by the finally so the marker never leaks.
+                self._handle_lock.enter_callback()
+                try:
+                    return callback(start_ms, end_ms, text.decode("utf-8") if text else "")
+                except BaseException as exc:
+                    cb_exc.append(exc)
+                    return False  # STOP: never let the exception cross ctypes
+                finally:
+                    self._handle_lock.exit_callback()
 
             cb = _cb
         else:
             cb = BASERT_SEGMENT_CALLBACK(0)  # NULL
 
-        result = self._lib.baseRT_transcribe_stream(
-            self._handle, wav_path.encode("utf-8"), lang, ctypes.byref(stats_c), cb, None
-        )
+        with self._handle_lock:
+            self._ensure_open()
+            result = self._lib.baseRT_transcribe_stream(
+                self._handle, wav_path.encode("utf-8"), lang, ctypes.byref(stats_c), cb, None
+            )
+        if cb_exc:
+            raise cb_exc[0]  # re-raise outside the ctypes boundary
         if not result:
             raise BaseRTError(get_error() or "transcription failed")
         return result.decode("utf-8"), TranscribeStats._from_c(stats_c)
@@ -1057,31 +1665,122 @@ class Model:
 
         Returns:
             Tuple of (transcribed_text, stats).
+
+        Warning:
+            ``callback`` runs synchronously while the native handle is busy. Do
+            NOT call other methods of this model from within it: a same-thread
+            call raises :class:`BaseRTError`, and delegating synchronously to a
+            DIFFERENT thread that then calls this model can DEADLOCK on the busy
+            handle. That is a single-owner-contract violation, not a defect. See
+            :meth:`generate`.
         """
         n = len(samples)
         arr = (ctypes.c_float * n)(*samples)
         stats_c = BaseRTTranscribeStats()
         lang = language.encode("utf-8") if language else None
 
+        # See generate(): the segment callback runs inside the native transcribe
+        # call via ctypes, which cannot propagate a Python exception across the C
+        # boundary. Stash it, STOP transcription (return False), re-raise after.
+        cb_exc: List[BaseException] = []
+
         if callback is not None:
             @BASERT_SEGMENT_CALLBACK
             def _cb(start_ms: int, end_ms: int, text: bytes, _ud: ctypes.c_void_p) -> bool:
-                return callback(start_ms, end_ms, text.decode("utf-8") if text else "")
+                # Runs synchronously inside the native transcribe call while
+                # _handle_lock is held on this thread -- mark in-callback so a
+                # re-entrant handle method raises instead of self-deadlocking;
+                # balanced by the finally so the marker never leaks.
+                self._handle_lock.enter_callback()
+                try:
+                    return callback(start_ms, end_ms, text.decode("utf-8") if text else "")
+                except BaseException as exc:
+                    cb_exc.append(exc)
+                    return False  # STOP: never let the exception cross ctypes
+                finally:
+                    self._handle_lock.exit_callback()
 
             cb = _cb
         else:
             cb = BASERT_SEGMENT_CALLBACK(0)  # NULL
 
-        result = self._lib.baseRT_transcribe_pcm_stream(
-            self._handle, arr, n, lang, ctypes.byref(stats_c), cb, None
-        )
+        with self._handle_lock:
+            self._ensure_open()
+            result = self._lib.baseRT_transcribe_pcm_stream(
+                self._handle, arr, n, lang, ctypes.byref(stats_c), cb, None
+            )
+        if cb_exc:
+            raise cb_exc[0]  # re-raise outside the ctypes boundary
         if not result:
             raise BaseRTError(get_error() or "transcription failed")
         return result.decode("utf-8"), TranscribeStats._from_c(stats_c)
 
     def set_timestamps(self, enabled: bool) -> None:
         """Enable or disable timestamp generation for Whisper transcription."""
-        self._lib.baseRT_set_timestamps(self._handle, enabled)
+        with self._handle_lock:
+            self._ensure_open()
+            self._lib.baseRT_set_timestamps(self._handle, enabled)
+
+    def set_task(self, task: str) -> None:
+        """Set the Whisper task: "transcribe" (default) or "translate".
+
+        Raises BaseRTError on an unknown task or on "translate" with an
+        English-only model.
+        """
+        with self._handle_lock:
+            self._ensure_open()
+            if not self._lib.baseRT_set_task(self._handle, task.encode("utf-8")):
+                raise BaseRTError(get_error() or "baseRT_set_task failed")
+
+    def set_initial_prompt(self, text: Optional[str]) -> None:
+        """Set an initial prompt to bias Whisper decoding (None clears it)."""
+        with self._handle_lock:
+            self._ensure_open()
+            self._lib.baseRT_set_initial_prompt(
+                self._handle, text.encode("utf-8") if text else None
+            )
+
+    def set_condition_on_previous_text(self, enabled: bool) -> None:
+        """Condition each 30s window on previous decoded text (default True)."""
+        with self._handle_lock:
+            self._ensure_open()
+            self._lib.baseRT_set_condition_on_previous_text(self._handle, enabled)
+
+    def transcribe_language(self) -> str:
+        """Language code of the last transcription (detected or requested)."""
+        with self._handle_lock:
+            self._ensure_open()
+            result = self._lib.baseRT_transcribe_language(self._handle)
+            return result.decode("utf-8") if result else ""
+
+    def transcribe_audio_duration_ms(self) -> int:
+        """Duration of the last transcription's source audio in milliseconds.
+
+        The OpenAI verbose_json ``duration`` field is this value in
+        fractional seconds. 0 if no transcription has run.
+        """
+        with self._handle_lock:
+            self._ensure_open()
+            return self._lib.baseRT_transcribe_audio_duration_ms(self._handle)
+
+    def transcribe_segments(self) -> List[TranscribeSegment]:
+        """Per-segment metadata for the last transcription.
+
+        Returns a list of :class:`TranscribeSegment` (start/end timestamps,
+        text, and the verbose_json quality metrics). Empty if no
+        transcription has run. Segment text is copied out, so the returned
+        list stays valid after later transcriptions.
+        """
+        with self._handle_lock:
+            self._ensure_open()
+            n = self._lib.baseRT_transcribe_segment_count(self._handle)
+            segments: List[TranscribeSegment] = []
+            for i in range(n):
+                seg_c = BaseRTTranscribeSegment()
+                if not self._lib.baseRT_transcribe_segment(self._handle, i, ctypes.byref(seg_c)):
+                    break
+                segments.append(TranscribeSegment._from_c(seg_c))
+            return segments
 
     # -- embeddings ----------------------------------------------------------
 
@@ -1095,11 +1794,23 @@ class Model:
         Returns:
             List of float embedding values.
         """
-        if max_dims <= 0:
-            max_dims = self._lib.baseRT_embedding_dim(self._handle)
-        arr = (ctypes.c_uint32 * len(tokens))(*tokens)
-        out = (ctypes.c_float * max_dims)()
-        dim = self._lib.baseRT_embed(self._handle, arr, len(tokens), out, max_dims)
+        # baseRT_embedding_dim + baseRT_embed both touch the handle; hold the
+        # lock across both so the sizing query and the embed cannot interleave
+        # with another handle user. Direct _lib calls (not the guarded
+        # embedding_dim property) so there is no nested re-acquire.
+        with self._handle_lock:
+            self._ensure_open()
+            # Capture the handle once under the lock. ctypes releases the GIL
+            # during each native call, so a concurrent close() could clear the
+            # self._handle attribute between the sizing query and the embed; a
+            # captured local stays valid for both. close() can only FREE under
+            # _handle_lock (held here), so the free waits until we release.
+            handle = self._handle
+            if max_dims <= 0:
+                max_dims = self._lib.baseRT_embedding_dim(handle)
+            arr = (ctypes.c_uint32 * len(tokens))(*tokens)
+            out = (ctypes.c_float * max_dims)()
+            dim = self._lib.baseRT_embed(handle, arr, len(tokens), out, max_dims)
         if dim <= 0:
             raise BaseRTError(get_error() or "embed failed")
         return list(out[:dim])
@@ -1114,12 +1825,19 @@ class Model:
         Returns:
             List of float embedding values.
         """
-        if max_dims <= 0:
-            max_dims = self._lib.baseRT_embedding_dim(self._handle)
-        out = (ctypes.c_float * max_dims)()
-        dim = self._lib.baseRT_embed_text(
-            self._handle, text.encode("utf-8"), out, max_dims
-        )
+        with self._handle_lock:
+            self._ensure_open()
+            # Capture once: the sizing query and the embed are two native calls
+            # under one lock, and each releases the GIL. A captured local keeps
+            # the handle stable across both even if a concurrent close() clears
+            # the self._handle attribute (its free still waits on _handle_lock).
+            handle = self._handle
+            if max_dims <= 0:
+                max_dims = self._lib.baseRT_embedding_dim(handle)
+            out = (ctypes.c_float * max_dims)()
+            dim = self._lib.baseRT_embed_text(
+                handle, text.encode("utf-8"), out, max_dims
+            )
         if dim <= 0:
             raise BaseRTError(get_error() or "embed_text failed")
         return list(out[:dim])
@@ -1127,7 +1845,9 @@ class Model:
     @property
     def embedding_dim(self) -> int:
         """Get the embedding dimension for this model."""
-        return self._lib.baseRT_embedding_dim(self._handle)
+        with self._handle_lock:
+            self._ensure_open()
+            return self._lib.baseRT_embedding_dim(self._handle)
 
     # -- chat templates ------------------------------------------------------
 
@@ -1141,9 +1861,11 @@ class Model:
         Returns:
             Formatted chat string.
         """
-        result = self._lib.baseRT_format_chat(
-            self._handle, system.encode("utf-8"), user.encode("utf-8")
-        )
+        with self._handle_lock:
+            self._ensure_open()
+            result = self._lib.baseRT_format_chat(
+                self._handle, system.encode("utf-8"), user.encode("utf-8")
+            )
         if not result:
             raise BaseRTError(get_error() or "format_chat failed")
         return result.decode("utf-8")
@@ -1151,7 +1873,9 @@ class Model:
     @property
     def chat_template(self) -> str:
         """Get the chat template name for the loaded model."""
-        result = self._lib.baseRT_chat_template(self._handle)
+        with self._handle_lock:
+            self._ensure_open()
+            result = self._lib.baseRT_chat_template(self._handle)
         return result.decode("utf-8") if result else ""
 
     # -- token counting ------------------------------------------------------
@@ -1165,34 +1889,69 @@ class Model:
         Returns:
             Number of tokens.
         """
-        return self._lib.baseRT_token_count(self._handle, text.encode("utf-8"))
+        with self._handle_lock:
+            self._ensure_open()
+            return self._lib.baseRT_token_count(self._handle, text.encode("utf-8"))
 
     # -- model inspection ----------------------------------------------------
 
     def tensors(self) -> List[TensorInfo]:
         """Return metadata for every tensor in the model."""
-        count = self._lib.baseRT_tensor_count(self._handle)
+        # Hold the lock across the whole enumeration: count and the per-index
+        # name/dtype lookups must observe a consistent handle state, and none of
+        # these are guarded methods, so there is no nested re-acquire.
         result: List[TensorInfo] = []
-        for i in range(count):
-            name_b = self._lib.baseRT_tensor_name(self._handle, i)
-            raw_b = self._lib.baseRT_tensor_raw_dtype(self._handle, i)
-            result.append(
-                TensorInfo(
-                    index=i,
-                    name=name_b.decode("utf-8") if name_b else "",
-                    dtype=self._lib.baseRT_tensor_dtype(self._handle, i),
-                    raw_dtype=raw_b.decode("utf-8") if raw_b else "",
+        with self._handle_lock:
+            self._ensure_open()
+            # Capture once: this enumerates many native calls (count + per-index
+            # name/raw_dtype/dtype), each releasing the GIL. A concurrent close()
+            # could clear the self._handle attribute mid-loop; the captured local
+            # keeps every call on the same valid handle. The actual free waits on
+            # _handle_lock, which we hold for the whole enumeration.
+            handle = self._handle
+            count = self._lib.baseRT_tensor_count(handle)
+            for i in range(count):
+                name_b = self._lib.baseRT_tensor_name(handle, i)
+                raw_b = self._lib.baseRT_tensor_raw_dtype(handle, i)
+                result.append(
+                    TensorInfo(
+                        index=i,
+                        name=name_b.decode("utf-8") if name_b else "",
+                        dtype=self._lib.baseRT_tensor_dtype(handle, i),
+                        raw_dtype=raw_b.decode("utf-8") if raw_b else "",
+                    )
                 )
-            )
         return result
 
     # -- helpers -------------------------------------------------------------
 
     def _to_token_array(
-        self, prompt: Union[str, List[int]]
+        self,
+        prompt: Union[str, List[int]],
+        handle: Optional[ctypes.c_void_p] = None,
     ) -> ctypes.Array[ctypes.c_uint32]:
+        """Coerce a prompt into a native token array.
+
+        When ``handle`` is ``None`` (the common path) tokenization of a string
+        prompt goes through the public, lifecycle-checked :meth:`encode`. When an
+        explicit ``handle`` is supplied the CALLER MUST have validated that
+        handle under a lock that blocks ``close()`` from freeing it -- the stream
+        worker captures a still-live handle under ``_streams_lock`` while
+        ``_closing`` is unset. ``_handle_lock`` is taken HERE, but only around the
+        native tokenize of a string prompt (the private
+        :meth:`_encode_with_handle`); a pre-tokenized list prompt issues no
+        native call and never touches ``_handle_lock``. No public code path can
+        supply a ``handle``, so no stale/foreign handle can enter here.
+        """
         if isinstance(prompt, str):
-            ids = self.encode(prompt)
+            if handle is None:
+                ids = self.encode(prompt)
+            else:
+                # Lock order _streams_lock -> _handle_lock (caller holds the
+                # former); mirrors the original encode(), which acquired
+                # _handle_lock internally around the same native call.
+                with self._handle_lock:
+                    ids = self._encode_with_handle(prompt, 8192, handle)
         else:
             ids = prompt
         arr = (ctypes.c_uint32 * len(ids))(*ids)

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -6,7 +6,7 @@ long_description = (here / "README.md").read_text(encoding="utf-8")
 
 setup(
     name="baseRT",
-    version="0.2.0",
+    version="0.2.1",
     description="Python bindings for the BaseRT LLM inference engine (Apple Silicon / Metal)",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/bindings/python/tests/test_baseRT.py
+++ b/bindings/python/tests/test_baseRT.py
@@ -11,6 +11,8 @@ import ctypes
 import os
 import struct
 import sys
+import threading
+import time
 from pathlib import Path
 from unittest import mock
 
@@ -75,7 +77,10 @@ class TestBaseRTModelConfig:
         assert indices == sorted(indices)
 
     def test_field_count(self):
-        assert len(BaseRTModelConfig._fields_) == 87
+        # Keep this in sync with include/baseRT/types.h. The runtime ABI-size
+        # assertion below catches layout drift; this count catches accidental
+        # omission of same-sized fields from the ctypes mirror.
+        assert len(BaseRTModelConfig._fields_) == 95
 
     def test_architecture_field_is_char_array(self):
         # architecture should be a fixed 32-byte char array
@@ -443,8 +448,11 @@ class TestFindLibrary:
             result = _find_library()
             assert result == fake_path
 
-    def test_raises_when_not_found(self):
-        # Clear env var and point __file__ somewhere with no build dir nearby
+    def test_raises_when_not_found(self, tmp_path, monkeypatch):
+        # Clear every resolver input. In particular, isolate cwd so a shared
+        # library produced by an earlier test/CI build cannot satisfy the
+        # fallback lookup and make this test order-dependent.
+        monkeypatch.chdir(tmp_path)
         with mock.patch.dict(os.environ, {}, clear=True):
             with mock.patch("baseRT.__file__", "/nonexistent/bindings/python/baseRT/__init__.py"):
                 with pytest.raises(OSError, match="Cannot find"):
@@ -584,6 +592,193 @@ class TestStructSizes:
 # -------------------------------------------------------------------------
 # _get_lib caching
 # -------------------------------------------------------------------------
+
+
+def _make_mock_model():
+    """Build a Model backed by a MagicMock C library (no GPU/model file).
+
+    baseRT_load_model returns a truthy fake handle so __init__ succeeds; every
+    other native symbol is a MagicMock attribute the tests configure as needed.
+    """
+    fake_lib = mock.MagicMock()
+    fake_lib.baseRT_load_model.return_value = 0xABCD  # truthy fake handle
+    with mock.patch("baseRT._get_lib", return_value=fake_lib):
+        m = baseRT.Model("dummy.base")
+    return m, fake_lib
+
+
+class TestCallbackInitiatedClose:
+    """Issue 1: close() from within a direct-path callback must be rejected
+    BEFORE any lifecycle state changes (no half-closed model)."""
+
+    def test_close_in_callback_raises_before_state_change(self):
+        m, _lib = _make_mock_model()
+        original_handle = m._handle
+
+        # Simulate being inside a direct generate/transcribe callback on this
+        # thread (the trampoline calls enter_callback around the user callback).
+        m._handle_lock.enter_callback()
+        try:
+            with pytest.raises(BaseRTError):
+                m.close()
+        finally:
+            m._handle_lock.exit_callback()
+
+        # The rejection must have happened at the TOP of close(): no lifecycle
+        # state may have been mutated.
+        assert m._closing is False
+        assert m._handle == original_handle
+        assert m._pending_free_handle is None
+
+        # And the model is still fully usable (a guarded method does not raise
+        # "model is closed").
+        _ = m.position  # would raise BaseRTError if _ensure_open saw it closed
+
+    def test_normal_close_still_works(self):
+        m, lib = _make_mock_model()
+        # Not inside a callback -> depth 0 -> close proceeds normally.
+        m.close()
+        assert m._closing is True
+        assert m._handle is None
+        assert m._pending_free_handle is None
+        lib.baseRT_free_model.assert_called_once_with(0xABCD)
+
+    def test_is_reentrant_helper(self):
+        lock = baseRT._ReentrancyGuardedLock()
+        assert lock.is_reentrant() is False
+        assert lock.in_callback() is False
+        lock.enter_callback()
+        try:
+            assert lock.is_reentrant() is True
+            assert lock.in_callback() is True
+        finally:
+            lock.exit_callback()
+        assert lock.is_reentrant() is False
+
+
+class TestStreamLifecycle:
+    """Stream-start lifecycle hardening:
+
+    * A stream worker QUEUED on _handle_lock that gets cancelled while it waits
+      must skip baseRT_generate entirely (not burn GPU on a dead stream), yet
+      still fire its done event and queue sentinel so nothing hangs.
+    * stream() must reject a callback-initiated start and a start on a closing
+      model BEFORE registering a worker / mutating lifecycle state.
+    """
+
+    def test_queued_then_cancelled_worker_skips_generate(self):
+        m, lib = _make_mock_model()
+
+        # Hold _handle_lock so the stream worker QUEUES behind it, exactly as if
+        # another handle call were in flight ahead of it.
+        m._handle_lock.acquire()
+
+        results = []
+
+        def consume():
+            results.append(list(m.stream([1, 2, 3])))
+
+        consumer = threading.Thread(target=consume, daemon=True)
+        consumer.start()
+
+        # Wait until the worker has registered and is blocked on the lock.
+        deadline = time.time() + 5
+        while not m._streams and time.time() < deadline:
+            time.sleep(0.005)
+        assert m._streams, "stream worker never registered"
+        cancel, _worker, done = m._streams[0]
+
+        # Cancel while the worker is still QUEUED, THEN release the lock so it
+        # acquires it and re-checks the cancel flag before the native call.
+        cancel.set()
+        m._handle_lock.release()
+
+        consumer.join(timeout=5)
+        assert not consumer.is_alive(), "consumer never completed"
+
+        # The worker acquired the lock, saw the cancel flag set, and skipped
+        # generation instead of entering baseRT_generate.
+        lib.baseRT_generate.assert_not_called()
+        # Early-out path still fired the completion event and queue sentinel.
+        assert done.is_set()
+        assert results == [[]]  # sentinel delivered, no tokens yielded
+        assert m._streams == []  # consumer deregistered the entry
+
+    def test_stream_in_callback_raises_before_register(self):
+        m, lib = _make_mock_model()
+
+        # Simulate being inside a direct generate/transcribe callback on this
+        # thread; starting a stream must be rejected up front.
+        m._handle_lock.enter_callback()
+        try:
+            with pytest.raises(BaseRTError):
+                next(m.stream([1, 2, 3]))
+        finally:
+            m._handle_lock.exit_callback()
+
+        # No worker registered, no native call issued.
+        assert m._streams == []
+        lib.baseRT_generate.assert_not_called()
+
+    def test_stream_while_closing_raises_before_register(self):
+        m, lib = _make_mock_model()
+        m._closing = True  # model is shutting down
+
+        with pytest.raises(BaseRTError):
+            next(m.stream([1, 2, 3]))
+
+        assert m._streams == []
+        lib.baseRT_generate.assert_not_called()
+
+
+class TestCompoundMethodStableHandle:
+    """Issue 2: a compound guarded method captures the handle into a local and
+    uses it for every native call, even if self._handle is cleared mid-method."""
+
+    def test_embed_uses_captured_handle(self):
+        m, lib = _make_mock_model()
+        original_handle = m._handle
+        seen = []
+
+        # The first native call clears the self._handle ATTRIBUTE, mimicking a
+        # concurrent close() that took ownership between the two native calls.
+        def dim_side_effect(handle):
+            m._handle = None
+            return 4
+
+        def embed_side_effect(handle, arr, n, out, max_dims):
+            seen.append(handle)
+            return max_dims
+
+        lib.baseRT_embedding_dim.side_effect = dim_side_effect
+        lib.baseRT_embed.side_effect = embed_side_effect
+
+        result = m.embed([1, 2, 3])
+
+        # The second native call must have received the still-valid captured
+        # handle, NOT the cleared None attribute.
+        assert seen == [original_handle]
+        assert len(result) == 4
+
+    def test_tensors_uses_captured_handle(self):
+        m, lib = _make_mock_model()
+        original_handle = m._handle
+        seen = []
+
+        def count_side_effect(handle):
+            m._handle = None  # concurrent close() clears the attribute
+            return 2
+
+        lib.baseRT_tensor_count.side_effect = count_side_effect
+        lib.baseRT_tensor_name.side_effect = lambda h, i: seen.append(h) or b"t"
+        lib.baseRT_tensor_raw_dtype.side_effect = lambda h, i: b"Q4_0"
+        lib.baseRT_tensor_dtype.side_effect = lambda h, i: 7
+
+        infos = m.tensors()
+
+        assert len(infos) == 2
+        # Every per-index call saw the captured handle, never None.
+        assert seen == [original_handle, original_handle]
 
 
 class TestGetLib:

--- a/bindings/rust/baseRT-sys/Cargo.toml
+++ b/bindings/rust/baseRT-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "baseRT-sys"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "Raw FFI bindings for the BaseRT LLM inference engine"
 license = "Apache-2.0"

--- a/bindings/rust/baseRT-sys/src/lib.rs
+++ b/bindings/rust/baseRT-sys/src/lib.rs
@@ -143,6 +143,35 @@ pub struct BaseRTTranscribeStats {
     pub total_ms: c_float,
 }
 
+/// One segment of the last transcription (verbose_json surface).
+/// `text` is borrowed from the engine — valid until the next transcription
+/// or model free.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct BaseRTTranscribeSegment {
+    pub start_ms: c_int,
+    pub end_ms: c_int,
+    pub text: *const c_char,
+    pub avg_logprob: c_float,
+    pub no_speech_prob: c_float,
+    pub compression_ratio: c_float,
+    pub temperature: c_float,
+}
+
+impl Default for BaseRTTranscribeSegment {
+    fn default() -> Self {
+        Self {
+            start_ms: 0,
+            end_ms: 0,
+            text: std::ptr::null(),
+            avg_logprob: 0.0,
+            no_speech_prob: 0.0,
+            compression_ratio: 0.0,
+            temperature: 0.0,
+        }
+    }
+}
+
 /// Sampling configuration for text generation.
 ///
 /// Extended in baseRT 0.2 with OpenAI-compat presence / frequency penalties,
@@ -298,6 +327,24 @@ extern "C" {
     ) -> *const c_char;
 
     pub fn baseRT_set_timestamps(model: baseRT_model_t, enabled: bool);
+
+    pub fn baseRT_set_task(model: baseRT_model_t, task: *const c_char) -> bool;
+
+    pub fn baseRT_set_initial_prompt(model: baseRT_model_t, text: *const c_char);
+
+    pub fn baseRT_set_condition_on_previous_text(model: baseRT_model_t, enabled: bool);
+
+    pub fn baseRT_transcribe_language(model: baseRT_model_t) -> *const c_char;
+
+    pub fn baseRT_transcribe_audio_duration_ms(model: baseRT_model_t) -> c_int;
+
+    pub fn baseRT_transcribe_segment_count(model: baseRT_model_t) -> c_int;
+
+    pub fn baseRT_transcribe_segment(
+        model: baseRT_model_t,
+        index: c_int,
+        out: *mut BaseRTTranscribeSegment,
+    ) -> bool;
 
     pub fn baseRT_is_whisper(model: baseRT_model_t) -> bool;
 

--- a/bindings/rust/baseRT/Cargo.toml
+++ b/bindings/rust/baseRT/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "baseRT"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "Safe Rust bindings for the BaseRT LLM inference engine (Apple Silicon)"
 license = "Apache-2.0"

--- a/bindings/rust/baseRT/src/lib.rs
+++ b/bindings/rust/baseRT/src/lib.rs
@@ -139,6 +139,27 @@ impl Default for SamplingConfig {
 }
 
 // ---------------------------------------------------------------------------
+// Transcription segments
+// ---------------------------------------------------------------------------
+
+/// One segment of the last transcription (verbose_json surface), with the
+/// text copied into owned memory.
+///
+/// `avg_logprob` / `no_speech_prob` / `compression_ratio` / `temperature`
+/// are window-level values applied to every segment decoded in that 30 s
+/// window (the engine's documented approximation).
+#[derive(Debug, Clone, PartialEq)]
+pub struct TranscribeSegment {
+    pub start_ms: i32,
+    pub end_ms: i32,
+    pub text: String,
+    pub avg_logprob: f32,
+    pub no_speech_prob: f32,
+    pub compression_ratio: f32,
+    pub temperature: f32,
+}
+
+// ---------------------------------------------------------------------------
 // Helper: read last error from C API
 // ---------------------------------------------------------------------------
 
@@ -284,7 +305,7 @@ impl Model {
     where
         F: FnMut(u32, &str) -> bool,
     {
-        let mut cb = CallbackWrapper { func: callback };
+        let mut cb = CallbackWrapper { func: callback, panic: None };
         let user_data = &mut cb as *mut CallbackWrapper<F> as *mut c_void;
 
         // Hold `_toks` / `_vals` alive across the FFI call — `ffi` carries
@@ -302,6 +323,9 @@ impl Model {
             )
         };
 
+        if let Some(payload) = cb.panic.take() {
+            std::panic::resume_unwind(payload);
+        }
         Ok(stats)
     }
 
@@ -318,7 +342,7 @@ impl Model {
     where
         F: FnMut(u32, &str) -> bool,
     {
-        let mut cb = CallbackWrapper { func: callback };
+        let mut cb = CallbackWrapper { func: callback, panic: None };
         let user_data = &mut cb as *mut CallbackWrapper<F> as *mut c_void;
 
         let (ffi, _toks, _vals) = sampling.to_ffi();
@@ -334,6 +358,9 @@ impl Model {
             )
         };
 
+        if let Some(payload) = cb.panic.take() {
+            std::panic::resume_unwind(payload);
+        }
         Ok(stats)
     }
 
@@ -478,7 +505,7 @@ impl Model {
         let lang_ptr = c_lang.as_ref().map_or(std::ptr::null(), |s| s.as_ptr());
 
         let mut stats = baseRT_sys::BaseRTTranscribeStats::default();
-        let mut wrapper = SegmentCallbackWrapper { func: &mut callback };
+        let mut wrapper = SegmentCallbackWrapper { func: &mut callback, panic: None };
         let user_data = &mut wrapper as *mut SegmentCallbackWrapper<F> as *mut c_void;
 
         let ptr = unsafe {
@@ -492,6 +519,9 @@ impl Model {
             )
         };
 
+        if let Some(payload) = wrapper.panic.take() {
+            std::panic::resume_unwind(payload);
+        }
         if ptr.is_null() {
             return Err(Error::Api(last_error()));
         }
@@ -514,7 +544,7 @@ impl Model {
         let lang_ptr = c_lang.as_ref().map_or(std::ptr::null(), |s| s.as_ptr());
 
         let mut stats = baseRT_sys::BaseRTTranscribeStats::default();
-        let mut wrapper = SegmentCallbackWrapper { func: &mut callback };
+        let mut wrapper = SegmentCallbackWrapper { func: &mut callback, panic: None };
         let user_data = &mut wrapper as *mut SegmentCallbackWrapper<F> as *mut c_void;
 
         let ptr = unsafe {
@@ -529,6 +559,9 @@ impl Model {
             )
         };
 
+        if let Some(payload) = wrapper.panic.take() {
+            std::panic::resume_unwind(payload);
+        }
         if ptr.is_null() {
             return Err(Error::Api(last_error()));
         }
@@ -540,6 +573,83 @@ impl Model {
     /// Enable or disable timestamp generation for Whisper transcription.
     pub fn set_timestamps(&self, enabled: bool) {
         unsafe { baseRT_sys::baseRT_set_timestamps(self.handle, enabled) }
+    }
+
+    /// Set the Whisper task: "transcribe" (default) or "translate".
+    ///
+    /// Errors on an unknown task or on "translate" with an English-only model.
+    pub fn set_task(&self, task: &str) -> Result<()> {
+        let c_task = CString::new(task).map_err(|_| Error::Api("task contains NUL".into()))?;
+        let ok = unsafe { baseRT_sys::baseRT_set_task(self.handle, c_task.as_ptr()) };
+        if ok {
+            Ok(())
+        } else {
+            Err(Error::Api(last_error()))
+        }
+    }
+
+    /// Set an initial prompt to bias Whisper decoding (`None` clears it).
+    pub fn set_initial_prompt(&self, text: Option<&str>) -> Result<()> {
+        match text {
+            Some(t) => {
+                let c_text = CString::new(t).map_err(|_| Error::Api("prompt contains NUL".into()))?;
+                unsafe { baseRT_sys::baseRT_set_initial_prompt(self.handle, c_text.as_ptr()) };
+            }
+            None => unsafe { baseRT_sys::baseRT_set_initial_prompt(self.handle, std::ptr::null()) },
+        }
+        Ok(())
+    }
+
+    /// Condition each 30s window on previous decoded text (default true).
+    pub fn set_condition_on_previous_text(&self, enabled: bool) {
+        unsafe { baseRT_sys::baseRT_set_condition_on_previous_text(self.handle, enabled) }
+    }
+
+    /// Language code of the last transcription (detected or requested).
+    pub fn transcribe_language(&self) -> String {
+        let ptr = unsafe { baseRT_sys::baseRT_transcribe_language(self.handle) };
+        if ptr.is_null() {
+            return String::new();
+        }
+        unsafe { CStr::from_ptr(ptr) }.to_string_lossy().into_owned()
+    }
+
+    /// Duration of the last transcription's source audio in milliseconds
+    /// (the OpenAI verbose_json `duration` field is this value in
+    /// fractional seconds). 0 if no transcription has run.
+    pub fn transcribe_audio_duration_ms(&self) -> i32 {
+        unsafe { baseRT_sys::baseRT_transcribe_audio_duration_ms(self.handle) }
+    }
+
+    /// Per-segment metadata for the last transcription (verbose_json
+    /// surface). Empty if no transcription has run. Segment text is copied
+    /// out, so the returned segments stay valid after later transcriptions.
+    pub fn transcribe_segments(&self) -> Vec<TranscribeSegment> {
+        let n = unsafe { baseRT_sys::baseRT_transcribe_segment_count(self.handle) };
+        let mut segments = Vec::with_capacity(n.max(0) as usize);
+        for i in 0..n {
+            let mut seg = baseRT_sys::BaseRTTranscribeSegment::default();
+            if !unsafe { baseRT_sys::baseRT_transcribe_segment(self.handle, i, &mut seg) } {
+                break;
+            }
+            let text = if seg.text.is_null() {
+                String::new()
+            } else {
+                unsafe { CStr::from_ptr(seg.text) }
+                    .to_string_lossy()
+                    .into_owned()
+            };
+            segments.push(TranscribeSegment {
+                start_ms: seg.start_ms,
+                end_ms: seg.end_ms,
+                text,
+                avg_logprob: seg.avg_logprob,
+                no_speech_prob: seg.no_speech_prob,
+                compression_ratio: seg.compression_ratio,
+                temperature: seg.temperature,
+            });
+        }
+        segments
     }
 
     // === Embeddings ===
@@ -708,10 +818,17 @@ impl<'a> ExactSizeIterator for TensorIter<'a> {}
 
 struct CallbackWrapper<F> {
     func: F,
+    /// Panic payload captured in the trampoline. Unwinding across the
+    /// `extern "C"` boundary would abort the process, so the trampoline
+    /// stashes it here and the caller resumes it once the FFI call has
+    /// returned to safe Rust.
+    panic: Option<Box<dyn std::any::Any + Send>>,
 }
 
 struct SegmentCallbackWrapper<'a, F> {
     func: &'a mut F,
+    /// See [`CallbackWrapper::panic`].
+    panic: Option<Box<dyn std::any::Any + Send>>,
 }
 
 unsafe extern "C" fn trampoline<F>(
@@ -723,12 +840,24 @@ where
     F: FnMut(u32, &str) -> bool,
 {
     let wrapper = &mut *(user_data as *mut CallbackWrapper<F>);
+    if wrapper.panic.is_some() {
+        // A previous invocation panicked; keep telling the engine to stop.
+        return false;
+    }
     let text_str = if text.is_null() {
         ""
     } else {
         CStr::from_ptr(text).to_str().unwrap_or("")
     };
-    (wrapper.func)(token_id, text_str)
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        (wrapper.func)(token_id, text_str)
+    })) {
+        Ok(keep_going) => keep_going,
+        Err(payload) => {
+            wrapper.panic = Some(payload);
+            false // stop generation so control returns to safe Rust
+        }
+    }
 }
 
 unsafe extern "C" fn segment_trampoline<F>(
@@ -741,12 +870,23 @@ where
     F: FnMut(i32, i32, &str) -> bool,
 {
     let wrapper = &mut *(user_data as *mut SegmentCallbackWrapper<F>);
+    if wrapper.panic.is_some() {
+        return false;
+    }
     let text_str = if text.is_null() {
         ""
     } else {
         CStr::from_ptr(text).to_str().unwrap_or("")
     };
-    (wrapper.func)(start_ms, end_ms, text_str)
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        (wrapper.func)(start_ms, end_ms, text_str)
+    })) {
+        Ok(keep_going) => keep_going,
+        Err(payload) => {
+            wrapper.panic = Some(payload);
+            false // stop transcription so control returns to safe Rust
+        }
+    }
 }
 
 #[cfg(test)]

--- a/bindings/swift/README.md
+++ b/bindings/swift/README.md
@@ -61,12 +61,12 @@ print("engine \(BaseRTEngine.version)")
 let model = try BaseRTModel(modelPath: "models/Qwen3-0.6B-Q4_0.base")
 
 // Check model info
-print("Architecture: \(model.config.architecture)")
-print("Memory: \(model.memoryUsage / 1_048_576) MB")
+print("Architecture: \(try model.config.architecture)")
+print("Memory: \(try model.memoryUsage / 1_048_576) MB")
 
 // Encode and generate
 let tokens = try model.encode(text: "Once upon a time")
-let stats = model.generate(tokens: tokens, maxTokens: 256) { token in
+let stats = try model.generate(tokens: tokens, maxTokens: 256) { token in
     print(token.text, terminator: "")
     return true  // return false to stop early
 }
@@ -84,7 +84,7 @@ let sampling = SamplingConfig(
     repeatPenalty: 1.1
 )
 
-model.generate(tokens: tokens, maxTokens: 512, sampling: sampling) { token in
+try model.generate(tokens: tokens, maxTokens: 512, sampling: sampling) { token in
     print(token.text, terminator: "")
     return true
 }
@@ -95,14 +95,14 @@ model.generate(tokens: tokens, maxTokens: 512, sampling: sampling) { token in
 ```swift
 // First turn
 let turn1 = try model.encode(text: "<|im_start|>user\nHello!<|im_end|>\n<|im_start|>assistant\n")
-model.generate(tokens: turn1, maxTokens: 256) { token in
+try model.generate(tokens: turn1, maxTokens: 256) { token in
     print(token.text, terminator: "")
     return true
 }
 
 // Continue from existing KV cache
 let turn2 = try model.encode(text: "<|im_end|>\n<|im_start|>user\nTell me more.<|im_end|>\n<|im_start|>assistant\n")
-model.generateContinue(tokens: turn2, maxTokens: 256) { token in
+try model.generateContinue(tokens: turn2, maxTokens: 256) { token in
     print(token.text, terminator: "")
     return true
 }
@@ -129,7 +129,7 @@ print(text)
 print("Took \(stats.totalMs)ms")
 
 // Disable timestamps for faster plain-text output
-whisper.setTimestamps(enabled: false)
+try whisper.setTimestamps(enabled: false)
 let (plainText, _) = try whisper.transcribe(wavPath: "audio.wav")
 print(plainText)
 
@@ -142,23 +142,34 @@ let (pcmText, pcmStats) = try whisper.transcribePCM(samples: samples)
 
 ```swift
 // Manual prefill + decode loop
-let firstToken = model.prefill(tokens: tokens)
+let firstToken = try model.prefill(tokens: tokens)
 var tok = firstToken
 for pos in tokens.count..<(tokens.count + 100) {
-    tok = model.decodeStep(tokenID: tok, position: pos)
-    print(model.decodeToken(tok), terminator: "")
+    tok = try model.decodeStep(tokenID: tok, position: pos)
+    print(try model.decodeToken(tok), terminator: "")
 }
 
 // Reset state for a new conversation
-model.reset()
+try model.reset()
 ```
+
+> Model APIs throw `BaseRTError.reentrantModelCall` if invoked from within a
+> generation/transcription callback (`onToken` / `onSegment`) **on the same
+> thread** — the native handle is exclusively busy for the callback's duration,
+> so the re-entrant call is rejected instead of corrupting state, and generation
+> continues past it. This guard is thread-local: if a callback instead hands work
+> **synchronously to another thread** that then calls the model (e.g.
+> `DispatchQueue.main.sync { try model.position }`), that call blocks on the busy
+> handle and can **deadlock**. That pattern violates the single-owner contract
+> (the handle is genuinely busy); do not call model APIs from a different thread
+> a callback is synchronously waiting on.
 
 ### Model Inspection
 
 ```swift
-for i in 0..<model.tensorCount {
-    if let name = model.tensorName(at: i) {
-        print("\(name): dtype=\(model.tensorDtype(at: i))")
+for i in 0..<(try model.tensorCount) {
+    if let name = try model.tensorName(at: i) {
+        print("\(name): dtype=\(try model.tensorDtype(at: i))")
     }
 }
 ```

--- a/bindings/swift/Sources/BaseRT/BaseRT.swift
+++ b/bindings/swift/Sources/BaseRT/BaseRT.swift
@@ -197,12 +197,38 @@ public enum BaseRTError: Error, LocalizedError, Sendable {
     case loadFailed(String)
     case encodeFailed(String)
     case transcribeFailed(String)
+    /// Thrown when a model API is called from within a generation/transcription
+    /// callback (`onToken` / `onSegment`) **on the same thread** while the native
+    /// handle is still busy running that generation. The handle is exclusively in
+    /// use for the callback's duration, so a same-thread re-entrant call is
+    /// rejected fast (this error) instead of corrupting KV/GPU state.
+    ///
+    /// The guard is thread-local, so it only covers same-thread re-entry. If a
+    /// callback instead hands work **synchronously to another thread** that then
+    /// calls the model, that call blocks on the busy handle and can **deadlock**
+    /// — it is *not* rejected. That pattern violates the single-owner contract
+    /// (do not call model APIs from a different thread a callback is
+    /// synchronously waiting on).
+    case reentrantModelCall
+    /// Thrown internally by `generateCore` when the caller's cancellation check
+    /// fires AFTER the handle lock is acquired but BEFORE the native generate
+    /// call starts. Used only by the stream worker to skip prompt prefill and
+    /// generation entirely for an already-cancelled stream; it is swallowed by
+    /// the worker (`try?`) and surfaces to callers as a cleanly finished,
+    /// empty stream. The public `generate` / `generateContinue` paths never pass
+    /// a cancellation check, so they never see this.
+    case cancelledBeforeGeneration
 
     public var errorDescription: String? {
         switch self {
         case .loadFailed(let msg): return "Failed to load model: \(msg)"
         case .encodeFailed(let msg): return "Encoding failed: \(msg)"
         case .transcribeFailed(let msg): return "Transcription failed: \(msg)"
+        case .reentrantModelCall:
+            return "Cannot call a model API from within a generation callback: "
+                + "the native handle is busy for the duration of the callback."
+        case .cancelledBeforeGeneration:
+            return "Generation was cancelled before it started."
         }
     }
 }
@@ -225,6 +251,29 @@ public struct TranscriptSegment: Sendable {
     public let text: String
 }
 
+/// One segment of the last transcription (verbose_json surface), with the
+/// text copied into owned memory.
+///
+/// `avgLogprob` / `noSpeechProb` / `compressionRatio` / `temperature` are
+/// window-level values applied to every segment decoded in that 30 s window
+/// (the engine's documented approximation).
+public struct TranscribeSegment: Sendable {
+    /// Start time in milliseconds.
+    public let startMs: Int
+    /// End time in milliseconds.
+    public let endMs: Int
+    /// Transcribed text for this segment.
+    public let text: String
+    /// Average token log-probability of the window's decode.
+    public let avgLogprob: Float
+    /// p(<|nospeech|>) at the window's SOT position.
+    public let noSpeechProb: Float
+    /// zlib compression ratio of the window's text.
+    public let compressionRatio: Float
+    /// Temperature of the accepted fallback-ladder attempt.
+    public let temperature: Float
+}
+
 // MARK: - BaseRTModel
 
 /// Swift wrapper around the BaseRT C inference engine.
@@ -232,6 +281,129 @@ public struct TranscriptSegment: Sendable {
 /// Thread safety: instances are not thread-safe. Use one model per thread/actor.
 public final class BaseRTModel {
     let handle: baseRT_model_t  // internal: used by extensions in this module
+
+    /// Serializes every native call that touches the non-thread-safe `handle`.
+    ///
+    /// The streaming worker runs `baseRT_generate` on a background thread via
+    /// `generate`/`generateContinue`, so it holds this lock for the FULL
+    /// duration of that dispatched call — not just until the cancellation flag
+    /// is observed. EVERY public method that touches `handle` — generation,
+    /// transcription, tokenization, embeddings, chat templating, the low-level
+    /// prefill/decode/chain-decode API, the multimodal/state/LoRA extension
+    /// APIs (see `BaseRTEngine.swift`), state mutators (`reset`,
+    /// `setSpeculation`, `setTimestamps`), and even the read-only info
+    /// accessors — acquires this lock before entering C. Because a stream's
+    /// background worker reuses `generate`/`generateContinue`, any subsequent
+    /// call acquires this lock before touching the handle and therefore waits
+    /// for the previous worker to fully return. This is the await-before-reuse
+    /// guarantee: even if a consumer `break`s (cancels) and immediately reuses
+    /// the model — via reset, prefill, another stream, anything — the next
+    /// call BLOCKS on this lock until the in-flight worker's `baseRT_generate`
+    /// returns and releases it, so two callers never overlap on the handle and
+    /// cannot corrupt KV/GPU state. Correctness (no overlap) is guaranteed;
+    /// only the promptness of the stop is best-effort (an in-flight C call
+    /// cannot be force-killed — see `IteratorCancellation`). The deinit path
+    /// never contends here: the worker closure retains `self` for its lifetime,
+    /// so deallocation (and `baseRT_free_model`) cannot begin while a worker is
+    /// in flight, and therefore never needs — and never takes — this lock.
+    ///
+    /// This is a NON-recursive lock. `baseRT_generate` / `baseRT_transcribe*`
+    /// invoke the user's `onToken` / segment callbacks WHILE this lock is held
+    /// on the worker thread AND while the handle is genuinely, exclusively busy.
+    /// SAME-THREAD re-entry from inside such a callback cannot be admitted here:
+    /// running a native call mid-generation corrupts KV/GPU state, and blocking
+    /// on this non-recursive lock (a same-thread re-entrant call) would deadlock.
+    /// So it is rejected fast, one level up, by the THREAD-LOCAL callback-depth
+    /// marker checked in `withHandleLock`, which throws
+    /// `BaseRTError.reentrantModelCall` before ever touching this lock — but ONLY
+    /// for a call made ON THE WORKER THREAD that is currently inside this model's
+    /// callback (see `callbackDepthKey`). Any OTHER thread that calls a model API
+    /// while a callback happens to be executing has a marker of 0, so it does NOT
+    /// throw: it falls through to this lock and block-and-waits until the worker's
+    /// native call returns, exactly as an ordinary concurrent caller does. That is
+    /// the deliberate difference from the former model-wide flag, which could not
+    /// tell callback-originated re-entry apart from unrelated concurrency and so
+    /// wrongly rejected legitimate concurrent callers.
+    ///
+    /// - Warning: The one case thread-local detection cannot rescue is a callback
+    ///   that synchronously hands work to a *different* thread which then calls
+    ///   this model — e.g. `onToken = { DispatchQueue.main.sync { try model.reset() } }`.
+    ///   That other thread's marker is 0, so it does not throw; it blocks on this
+    ///   lock while the worker (parked inside `.sync`) still holds it, and the two
+    ///   deadlock. This is NOT eliminated — it is a single-owner-contract
+    ///   violation: do NOT call model APIs from a *different* thread that a
+    ///   callback is synchronously waiting on. The supported reentry case — a
+    ///   same-thread call from within the callback — throws `reentrantModelCall`
+    ///   cleanly instead.
+    let handleLock = NSLock()
+
+    /// Per-instance key under which this model records, in the CURRENT thread's
+    /// `threadDictionary`, the depth of user callbacks (`onToken` / `onSegment`)
+    /// currently executing FOR THIS MODEL on that thread. It replaces the former
+    /// model-wide `os_unfair_lock`-guarded boolean, which could not distinguish a
+    /// callback-originated re-entrant call from an ordinary concurrent call made
+    /// on an unrelated thread while a callback happened to be running.
+    ///
+    /// Because the token/segment trampolines run on the worker thread, the marker
+    /// lives on the worker thread: `withHandleLock` throws only when it sees a
+    /// non-zero depth on the CALLING thread, i.e. a genuine same-thread re-entry.
+    /// The key is per instance (a unique string) so that being inside model A's
+    /// callback never rejects a call to a DIFFERENT model B from the same thread.
+    /// A depth counter (not a bool) makes nested callbacks safe.
+    private let callbackDepthKey = "com.baseRT.callbackDepth.\(UUID().uuidString)"
+
+    /// Increment this thread's callback depth for this model. Called by the
+    /// trampolines immediately before invoking the USER's closure. NOT called for
+    /// the internal AsyncStream yield path, which never runs user model-reentrant
+    /// code (marking it would spuriously reject consumers that legitimately call
+    /// the model between yielded tokens).
+    func enterCallbackScope() {
+        let dict = Thread.current.threadDictionary
+        let depth = (dict[callbackDepthKey] as? Int) ?? 0
+        dict[callbackDepthKey] = depth + 1
+    }
+
+    /// Decrement this thread's callback depth for this model. Called in a `defer`
+    /// by the trampolines right after the user's closure returns.
+    func exitCallbackScope() {
+        let dict = Thread.current.threadDictionary
+        let depth = (dict[callbackDepthKey] as? Int) ?? 0
+        if depth <= 1 {
+            dict.removeObject(forKey: callbackDepthKey)
+        } else {
+            dict[callbackDepthKey] = depth - 1
+        }
+    }
+
+    /// Whether THE CURRENT THREAD is presently inside one of this model's user
+    /// callbacks. True only on the worker thread while its `onToken` / `onSegment`
+    /// closure runs; false on every other thread, including threads that call the
+    /// model concurrently during that window.
+    private var isInCallbackOnCurrentThread: Bool {
+        ((Thread.current.threadDictionary[callbackDepthKey] as? Int) ?? 0) > 0
+    }
+
+    /// Reject same-thread re-entrant calls, then run `body` while holding
+    /// `handleLock` so the native handle is touched by at most one worker at a
+    /// time.
+    ///
+    /// If the CURRENT thread is already inside one of this model's callbacks
+    /// (`isInCallbackOnCurrentThread`), the handle is busy on this very thread and
+    /// a re-entrant native call would corrupt KV/GPU state (or deadlock the
+    /// non-recursive lock): throw `BaseRTError.reentrantModelCall` immediately,
+    /// BEFORE acquiring the lock. Every OTHER thread — including one that calls a
+    /// model API while a callback happens to be executing on the worker thread —
+    /// has a zero marker, so it does NOT throw: it falls through to `handleLock`
+    /// and block-and-waits until the in-flight native call returns, exactly as an
+    /// ordinary concurrent caller does. This is the behavior the former model-wide
+    /// flag got wrong (it rejected such unrelated callers too).
+    @inline(__always)
+    func withHandleLock<T>(_ body: () throws -> T) throws -> T {
+        if isInCallbackOnCurrentThread { throw BaseRTError.reentrantModelCall }
+        handleLock.lock()
+        defer { handleLock.unlock() }
+        return try body()
+    }
 
     // MARK: Lifecycle
 
@@ -253,29 +425,37 @@ public final class BaseRTModel {
     }
 
     deinit {
+        // The thread-local callback-depth marker needs no teardown here: it lives
+        // in each worker thread's `threadDictionary` and is always balanced by the
+        // trampoline's `defer` before the native call returns, so nothing survives
+        // past generation. deinit takes no lock and simply frees the handle.
         baseRT_free_model(handle)
     }
 
     // MARK: Model info
 
     /// The model configuration (dimensions, layers, architecture, etc.).
+    /// - Throws: `BaseRTError.reentrantModelCall` if read from within a callback.
     public var config: ModelConfig {
-        ModelConfig(baseRT_get_config(handle))
+        get throws { try withHandleLock { ModelConfig(baseRT_get_config(handle)) } }
     }
 
     /// Total GPU memory used by the model, in bytes.
+    /// - Throws: `BaseRTError.reentrantModelCall` if read from within a callback.
     public var memoryUsage: Int {
-        baseRT_model_memory(handle)
+        get throws { try withHandleLock { baseRT_model_memory(handle) } }
     }
 
     /// Whether this is a Whisper audio model.
+    /// - Throws: `BaseRTError.reentrantModelCall` if read from within a callback.
     public var isWhisper: Bool {
-        baseRT_is_whisper(handle)
+        get throws { try withHandleLock { baseRT_is_whisper(handle) } }
     }
 
     /// Current KV cache position (number of tokens processed so far).
+    /// - Throws: `BaseRTError.reentrantModelCall` if read from within a callback.
     public var position: Int {
-        Int(baseRT_get_position(handle))
+        get throws { try withHandleLock { Int(baseRT_get_position(handle)) } }
     }
 
     // MARK: Tokenization
@@ -286,25 +466,33 @@ public final class BaseRTModel {
     /// - Returns: Array of token IDs.
     /// - Throws: `BaseRTError.encodeFailed` if encoding fails.
     public func encode(text: String) throws -> [UInt32] {
-        let maxTokens = max(text.utf8.count * 2, 1024)
-        var tokens = [UInt32](repeating: 0, count: maxTokens)
-        let count = baseRT_encode(handle, text, &tokens, Int32(maxTokens))
-        if count < 0 {
-            let err = baseRT_get_error().flatMap { String(cString: $0) } ?? "encoding failed"
-            throw BaseRTError.encodeFailed(err)
+        // Serialized against every other handle-touching call (see handleLock);
+        // rejects re-entry from a callback.
+        try withHandleLock {
+            let maxTokens = max(text.utf8.count * 2, 1024)
+            var tokens = [UInt32](repeating: 0, count: maxTokens)
+            let count = baseRT_encode(handle, text, &tokens, Int32(maxTokens))
+            if count < 0 {
+                let err = baseRT_get_error().flatMap { String(cString: $0) } ?? "encoding failed"
+                throw BaseRTError.encodeFailed(err)
+            }
+            return Array(tokens.prefix(Int(count)))
         }
-        return Array(tokens.prefix(Int(count)))
     }
 
     /// Decode a single token ID back to its text representation.
     ///
     /// - Parameter tokenID: The token ID to decode.
     /// - Returns: The text for this token, or an empty string if invalid.
-    public func decodeToken(_ tokenID: UInt32) -> String {
-        guard let ptr = baseRT_decode_token(handle, tokenID) else {
-            return ""
+    /// - Throws: `BaseRTError.reentrantModelCall` if called from within a callback.
+    public func decodeToken(_ tokenID: UInt32) throws -> String {
+        // Serialized against every other handle-touching call (see handleLock).
+        try withHandleLock {
+            guard let ptr = baseRT_decode_token(handle, tokenID) else {
+                return ""
+            }
+            return String(cString: ptr)
         }
-        return String(cString: ptr)
     }
 
     // MARK: Generation
@@ -318,42 +506,34 @@ public final class BaseRTModel {
     ///   - onToken: Optional closure called for each generated token.
     ///              Return `false` to stop generation early.
     /// - Returns: Generation statistics.
+    ///
+    /// - Warning: `onToken` runs synchronously on the worker thread while the
+    ///   native handle is busy. Calling ANY method of this same model from inside
+    ///   `onToken` ON THE SAME (worker) THREAD THROWS
+    ///   `BaseRTError.reentrantModelCall` rather than corrupting the busy handle
+    ///   or self-deadlocking the non-recursive handle lock; generation continues
+    ///   past the rejected call. Callbacks that do not re-enter the model (return
+    ///   a value, append to a buffer, hand the token to another queue/stream) are
+    ///   unaffected.
+    ///
+    ///   The reentrancy guard is THREAD-LOCAL, so this does NOT cover a callback
+    ///   that synchronously hands work to a *different* thread which then calls
+    ///   this model — e.g. `onToken = { DispatchQueue.main.sync { try model.reset() } }`.
+    ///   That other thread is not marked as inside a callback, so it does not
+    ///   throw; it blocks on the handle lock the worker still holds and the two
+    ///   deadlock. This is not eliminated — it is a single-owner-contract
+    ///   violation: do NOT call model APIs from a different thread that a callback
+    ///   is synchronously waiting on.
     @discardableResult
     public func generate(
         tokens: [UInt32],
         maxTokens: Int,
         sampling: SamplingConfig = SamplingConfig(),
         onToken: ((GeneratedToken) -> Bool)? = nil
-    ) -> GenerationStats {
-        let stats = tokens.withUnsafeBufferPointer { buf in
-            sampling.withCValue { cfg in
-                if let callback = onToken {
-                    let ctx = CallbackContext(callback: callback)
-                    let unmanaged = Unmanaged.passRetained(ctx)
-                    defer { unmanaged.release() }
-                    return baseRT_generate(
-                        handle,
-                        buf.baseAddress,
-                        Int32(tokens.count),
-                        Int32(maxTokens),
-                        cfg,
-                        cTokenCallback,
-                        unmanaged.toOpaque()
-                    )
-                } else {
-                    return baseRT_generate(
-                        handle,
-                        buf.baseAddress,
-                        Int32(tokens.count),
-                        Int32(maxTokens),
-                        cfg,
-                        nil,
-                        nil
-                    )
-                }
-            }
-        }
-        return GenerationStats(stats)
+    ) throws -> GenerationStats {
+        try generateCore(
+            tokens: tokens, maxTokens: maxTokens, sampling: sampling,
+            onToken: onToken, isContinuation: false, guardCallback: true)
     }
 
     /// Continue generating from the current KV cache state (for multi-turn chat).
@@ -365,38 +545,90 @@ public final class BaseRTModel {
     ///   - onToken: Optional closure called for each generated token.
     ///              Return `false` to stop generation early.
     /// - Returns: Generation statistics.
+    ///
+    /// - Warning: `onToken` runs synchronously while the native handle is busy.
+    ///   Calling this model from inside `onToken` ON THE SAME (worker) THREAD
+    ///   THROWS `BaseRTError.reentrantModelCall`. A callback that synchronously
+    ///   hops to a *different* thread which then calls this model is a
+    ///   single-owner-contract violation that can deadlock and is NOT caught. See
+    ///   `generate(tokens:maxTokens:...)`.
     @discardableResult
     public func generateContinue(
         tokens: [UInt32],
         maxTokens: Int,
         sampling: SamplingConfig = SamplingConfig(),
         onToken: ((GeneratedToken) -> Bool)? = nil
-    ) -> GenerationStats {
-        let stats = tokens.withUnsafeBufferPointer { buf in
-            sampling.withCValue { cfg in
-                if let callback = onToken {
-                    let ctx = CallbackContext(callback: callback)
-                    let unmanaged = Unmanaged.passRetained(ctx)
-                    defer { unmanaged.release() }
-                    return baseRT_generate_continue(
-                        handle,
-                        buf.baseAddress,
-                        Int32(tokens.count),
-                        Int32(maxTokens),
-                        cfg,
-                        cTokenCallback,
-                        unmanaged.toOpaque()
-                    )
-                } else {
-                    return baseRT_generate_continue(
-                        handle,
-                        buf.baseAddress,
-                        Int32(tokens.count),
-                        Int32(maxTokens),
-                        cfg,
-                        nil,
-                        nil
-                    )
+    ) throws -> GenerationStats {
+        try generateCore(
+            tokens: tokens, maxTokens: maxTokens, sampling: sampling,
+            onToken: onToken, isContinuation: true, guardCallback: true)
+    }
+
+    /// Shared implementation for `generate` / `generateContinue` and the internal
+    /// AsyncStream worker.
+    ///
+    /// - Parameter guardCallback: when true (the direct user-facing paths), the
+    ///   token trampoline increments the worker thread's callback-depth marker
+    ///   around the user's `onToken` so a same-thread re-entrant model call throws
+    ///   instead of corrupting/deadlocking. The AsyncStream worker passes `false`:
+    ///   its `onToken` only does `continuation.yield` and never runs user
+    ///   model-reentrant code, so marking it would spuriously reject consumers
+    ///   that legitimately call the model between tokens.
+    @discardableResult
+    func generateCore(
+        tokens: [UInt32],
+        maxTokens: Int,
+        sampling: SamplingConfig,
+        onToken: ((GeneratedToken) -> Bool)?,
+        isContinuation: Bool,
+        guardCallback: Bool,
+        shouldCancelBeforeGenerate: (() -> Bool)? = nil
+    ) throws -> GenerationStats {
+        // Hold the handle lock across the whole native call so a concurrent
+        // reuse (including a freshly started stream worker) waits for us here;
+        // reject re-entry from an active callback before locking.
+        let stats = try withHandleLock { () throws -> BaseRTGenerationStats in
+            // We now own serialization of the handle. If the stream that
+            // dispatched us was cancelled while we were queued behind another
+            // in-flight worker for this lock, honor it HERE — before the native
+            // call — so we skip prompt prefill and generation entirely instead
+            // of burning GPU time only to have the first token callback return
+            // false. The lock is still released by withHandleLock's defer on
+            // this throw, so it is not leaked.
+            if shouldCancelBeforeGenerate?() == true {
+                throw BaseRTError.cancelledBeforeGeneration
+            }
+            return tokens.withUnsafeBufferPointer { buf in
+                sampling.withCValue { cfg in
+                    let cGen = isContinuation ? baseRT_generate_continue : baseRT_generate
+                    if let callback = onToken {
+                        // guardModel non-nil => trampoline increments the thread-
+                        // local callback-depth marker around the user closure; nil
+                        // for the stream yield path.
+                        let ctx = CallbackContext(
+                            callback: callback, guardModel: guardCallback ? self : nil)
+                        let unmanaged = Unmanaged.passRetained(ctx)
+                        defer { unmanaged.release() }
+                        return cGen(
+                            handle,
+                            buf.baseAddress,
+                            Int32(tokens.count),
+                            Int32(maxTokens),
+                            cfg,
+                            cTokenCallback,
+                            unmanaged.toOpaque()
+                        )
+                    } else {
+                        return cGen(
+                            handle,
+                            buf.baseAddress,
+                            Int32(tokens.count),
+                            Int32(maxTokens),
+                            cfg,
+                            nil,
+                            nil
+                        )
+                    }
                 }
             }
         }
@@ -413,12 +645,16 @@ public final class BaseRTModel {
     /// - Returns: Tuple of transcribed text and timing statistics.
     /// - Throws: `BaseRTError.transcribeFailed` if transcription fails.
     public func transcribe(wavPath: String, language: String = "en") throws -> (String, TranscribeStats) {
-        var stats = BaseRTTranscribeStats()
-        guard let result = baseRT_transcribe(handle, wavPath, language, &stats) else {
-            let err = baseRT_get_error().flatMap { String(cString: $0) } ?? "transcription failed"
-            throw BaseRTError.transcribeFailed(err)
+        // Serialized against every other handle-touching call (see handleLock);
+        // rejects re-entry from a callback.
+        try withHandleLock {
+            var stats = BaseRTTranscribeStats()
+            guard let result = baseRT_transcribe(handle, wavPath, language, &stats) else {
+                let err = baseRT_get_error().flatMap { String(cString: $0) } ?? "transcription failed"
+                throw BaseRTError.transcribeFailed(err)
+            }
+            return (String(cString: result), TranscribeStats(stats))
         }
-        return (String(cString: result), TranscribeStats(stats))
     }
 
     /// Transcribe audio from a WAV file with per-segment streaming.
@@ -431,22 +667,33 @@ public final class BaseRTModel {
     ///                Return `false` to stop transcription early.
     /// - Returns: Tuple of full transcribed text and timing statistics.
     /// - Throws: `BaseRTError.transcribeFailed` if transcription fails.
+    ///
+    /// - Warning: `onSegment` runs synchronously while the native handle is busy.
+    ///   Calling this model from inside `onSegment` ON THE SAME (worker) THREAD
+    ///   THROWS `BaseRTError.reentrantModelCall` rather than corrupting the busy
+    ///   handle or self-deadlocking. A callback that synchronously hops to a
+    ///   *different* thread which then calls this model is a
+    ///   single-owner-contract violation that can deadlock and is NOT caught. See
+    ///   `generate(tokens:maxTokens:...)`.
     public func transcribe(
         wavPath: String,
         language: String = "en",
         onSegment: @escaping (TranscriptSegment) -> Bool
     ) throws -> (String, TranscribeStats) {
-        var stats = BaseRTTranscribeStats()
-        let ctx = SegmentCallbackContext(callback: onSegment)
-        let unmanaged = Unmanaged.passRetained(ctx)
-        defer { unmanaged.release() }
-        guard let result = baseRT_transcribe_stream(
-            handle, wavPath, language, &stats, cSegmentCallback, unmanaged.toOpaque()
-        ) else {
-            let err = baseRT_get_error().flatMap { String(cString: $0) } ?? "transcription failed"
-            throw BaseRTError.transcribeFailed(err)
+        // Serialized against every other handle-touching call (see handleLock).
+        try withHandleLock {
+            var stats = BaseRTTranscribeStats()
+            let ctx = SegmentCallbackContext(callback: onSegment, guardModel: self)
+            let unmanaged = Unmanaged.passRetained(ctx)
+            defer { unmanaged.release() }
+            guard let result = baseRT_transcribe_stream(
+                handle, wavPath, language, &stats, cSegmentCallback, unmanaged.toOpaque()
+            ) else {
+                let err = baseRT_get_error().flatMap { String(cString: $0) } ?? "transcription failed"
+                throw BaseRTError.transcribeFailed(err)
+            }
+            return (String(cString: result), TranscribeStats(stats))
         }
-        return (String(cString: result), TranscribeStats(stats))
     }
 
     /// Transcribe audio from raw PCM samples (16kHz, mono, Float32).
@@ -457,38 +704,53 @@ public final class BaseRTModel {
     /// - Returns: Tuple of transcribed text and timing statistics.
     /// - Throws: `BaseRTError.transcribeFailed` if transcription fails.
     public func transcribePCM(samples: [Float], language: String = "en") throws -> (String, TranscribeStats) {
-        var stats = BaseRTTranscribeStats()
-        let result = samples.withUnsafeBufferPointer { buf in
-            baseRT_transcribe_pcm(handle, buf.baseAddress, Int32(samples.count), language, &stats)
+        // Serialized against every other handle-touching call (see handleLock);
+        // rejects re-entry from a callback.
+        try withHandleLock {
+            var stats = BaseRTTranscribeStats()
+            let result = samples.withUnsafeBufferPointer { buf in
+                baseRT_transcribe_pcm(handle, buf.baseAddress, Int32(samples.count), language, &stats)
+            }
+            guard let result else {
+                let err = baseRT_get_error().flatMap { String(cString: $0) } ?? "transcription failed"
+                throw BaseRTError.transcribeFailed(err)
+            }
+            return (String(cString: result), TranscribeStats(stats))
         }
-        guard let result else {
-            let err = baseRT_get_error().flatMap { String(cString: $0) } ?? "transcription failed"
-            throw BaseRTError.transcribeFailed(err)
-        }
-        return (String(cString: result), TranscribeStats(stats))
     }
 
     /// Transcribe raw PCM samples with per-segment streaming.
+    ///
+    /// - Warning: `onSegment` runs synchronously while the native handle is busy.
+    ///   Calling this model from inside `onSegment` ON THE SAME (worker) THREAD
+    ///   THROWS `BaseRTError.reentrantModelCall` rather than corrupting the busy
+    ///   handle or self-deadlocking. A callback that synchronously hops to a
+    ///   *different* thread which then calls this model is a
+    ///   single-owner-contract violation that can deadlock and is NOT caught. See
+    ///   `generate(tokens:maxTokens:...)`.
     public func transcribePCM(
         samples: [Float],
         language: String = "en",
         onSegment: @escaping (TranscriptSegment) -> Bool
     ) throws -> (String, TranscribeStats) {
-        var stats = BaseRTTranscribeStats()
-        let ctx = SegmentCallbackContext(callback: onSegment)
-        let unmanaged = Unmanaged.passRetained(ctx)
-        defer { unmanaged.release() }
-        let result = samples.withUnsafeBufferPointer { buf in
-            baseRT_transcribe_pcm_stream(
-                handle, buf.baseAddress, Int32(samples.count), language, &stats,
-                cSegmentCallback, unmanaged.toOpaque()
-            )
+        // Serialized against every other handle-touching call (see handleLock).
+        try withHandleLock {
+            var stats = BaseRTTranscribeStats()
+            let ctx = SegmentCallbackContext(callback: onSegment, guardModel: self)
+            let unmanaged = Unmanaged.passRetained(ctx)
+            defer { unmanaged.release() }
+            let result = samples.withUnsafeBufferPointer { buf in
+                baseRT_transcribe_pcm_stream(
+                    handle, buf.baseAddress, Int32(samples.count), language, &stats,
+                    cSegmentCallback, unmanaged.toOpaque()
+                )
+            }
+            guard let result else {
+                let err = baseRT_get_error().flatMap { String(cString: $0) } ?? "transcription failed"
+                throw BaseRTError.transcribeFailed(err)
+            }
+            return (String(cString: result), TranscribeStats(stats))
         }
-        guard let result else {
-            let err = baseRT_get_error().flatMap { String(cString: $0) } ?? "transcription failed"
-            throw BaseRTError.transcribeFailed(err)
-        }
-        return (String(cString: result), TranscribeStats(stats))
     }
 
     // MARK: Embeddings
@@ -499,20 +761,26 @@ public final class BaseRTModel {
     /// - Returns: Array of float embedding values.
     /// - Throws: `BaseRTError.encodeFailed` if embedding fails.
     public func embed(tokens: [UInt32]) throws -> [Float] {
-        let dim = Int(baseRT_embedding_dim(handle))
-        guard dim > 0 else {
-            let err = baseRT_get_error().flatMap { String(cString: $0) } ?? "embedding failed"
-            throw BaseRTError.encodeFailed(err)
+        // Serialized against every other handle-touching call (see handleLock);
+        // rejects re-entry from a callback. Calls the C `baseRT_embedding_dim`
+        // directly (not the `embeddingDim` property) to avoid a redundant
+        // re-lock — the non-recursive lock cannot be nested on one thread.
+        try withHandleLock {
+            let dim = Int(baseRT_embedding_dim(handle))
+            guard dim > 0 else {
+                let err = baseRT_get_error().flatMap { String(cString: $0) } ?? "embedding failed"
+                throw BaseRTError.encodeFailed(err)
+            }
+            var out = [Float](repeating: 0, count: dim)
+            let n = tokens.withUnsafeBufferPointer { buf in
+                baseRT_embed(handle, buf.baseAddress, Int32(tokens.count), &out, Int32(dim))
+            }
+            guard n > 0 else {
+                let err = baseRT_get_error().flatMap { String(cString: $0) } ?? "embedding failed"
+                throw BaseRTError.encodeFailed(err)
+            }
+            return Array(out.prefix(Int(n)))
         }
-        var out = [Float](repeating: 0, count: dim)
-        let n = tokens.withUnsafeBufferPointer { buf in
-            baseRT_embed(handle, buf.baseAddress, Int32(tokens.count), &out, Int32(dim))
-        }
-        guard n > 0 else {
-            let err = baseRT_get_error().flatMap { String(cString: $0) } ?? "embedding failed"
-            throw BaseRTError.encodeFailed(err)
-        }
-        return Array(out.prefix(Int(n)))
     }
 
     /// Compute embeddings from text directly (tokenizes internally).
@@ -521,23 +789,30 @@ public final class BaseRTModel {
     /// - Returns: Array of float embedding values.
     /// - Throws: `BaseRTError.encodeFailed` if embedding fails.
     public func embedText(_ text: String) throws -> [Float] {
-        let dim = Int(baseRT_embedding_dim(handle))
-        guard dim > 0 else {
-            let err = baseRT_get_error().flatMap { String(cString: $0) } ?? "embedding failed"
-            throw BaseRTError.encodeFailed(err)
+        // Serialized against every other handle-touching call (see handleLock);
+        // rejects re-entry from a callback. Calls the C `baseRT_embedding_dim`
+        // directly (not the `embeddingDim` property) to avoid a redundant
+        // re-lock — the non-recursive lock cannot be nested on one thread.
+        try withHandleLock {
+            let dim = Int(baseRT_embedding_dim(handle))
+            guard dim > 0 else {
+                let err = baseRT_get_error().flatMap { String(cString: $0) } ?? "embedding failed"
+                throw BaseRTError.encodeFailed(err)
+            }
+            var out = [Float](repeating: 0, count: dim)
+            let n = baseRT_embed_text(handle, text, &out, Int32(dim))
+            guard n > 0 else {
+                let err = baseRT_get_error().flatMap { String(cString: $0) } ?? "embedding failed"
+                throw BaseRTError.encodeFailed(err)
+            }
+            return Array(out.prefix(Int(n)))
         }
-        var out = [Float](repeating: 0, count: dim)
-        let n = baseRT_embed_text(handle, text, &out, Int32(dim))
-        guard n > 0 else {
-            let err = baseRT_get_error().flatMap { String(cString: $0) } ?? "embedding failed"
-            throw BaseRTError.encodeFailed(err)
-        }
-        return Array(out.prefix(Int(n)))
     }
 
     /// The embedding dimension for this model.
+    /// - Throws: `BaseRTError.reentrantModelCall` if read from within a callback.
     public var embeddingDim: Int {
-        Int(baseRT_embedding_dim(handle))
+        get throws { try withHandleLock { Int(baseRT_embedding_dim(handle)) } }
     }
 
     // MARK: Chat templates
@@ -548,19 +823,28 @@ public final class BaseRTModel {
     ///   - system: System prompt.
     ///   - user: User message.
     /// - Returns: Formatted chat string.
-    public func formatChat(system: String, user: String) -> String {
-        guard let ptr = baseRT_format_chat(handle, system, user) else {
-            return ""
+    /// - Throws: `BaseRTError.reentrantModelCall` if called from within a callback.
+    public func formatChat(system: String, user: String) throws -> String {
+        // Serialized against every other handle-touching call (see handleLock).
+        try withHandleLock {
+            guard let ptr = baseRT_format_chat(handle, system, user) else {
+                return ""
+            }
+            return String(cString: ptr)
         }
-        return String(cString: ptr)
     }
 
     /// The chat template name for the loaded model (e.g. "chatml", "llama3", "gemma").
+    /// - Throws: `BaseRTError.reentrantModelCall` if read from within a callback.
     public var chatTemplate: String {
-        guard let ptr = baseRT_chat_template(handle) else {
-            return ""
+        get throws {
+            try withHandleLock {
+                guard let ptr = baseRT_chat_template(handle) else {
+                    return ""
+                }
+                return String(cString: ptr)
+            }
         }
-        return String(cString: ptr)
     }
 
     // MARK: Token counting
@@ -569,8 +853,9 @@ public final class BaseRTModel {
     ///
     /// - Parameter text: Input text.
     /// - Returns: Number of tokens.
-    public func tokenCount(_ text: String) -> Int {
-        Int(baseRT_token_count(handle, text))
+    /// - Throws: `BaseRTError.reentrantModelCall` if called from within a callback.
+    public func tokenCount(_ text: String) throws -> Int {
+        try withHandleLock { Int(baseRT_token_count(handle, text)) }
     }
 
     // MARK: Whisper settings
@@ -579,63 +864,152 @@ public final class BaseRTModel {
     ///
     /// When enabled (default), output includes `[start --> end] text` segments.
     /// When disabled, faster greedy decode produces plain text only.
-    public func setTimestamps(enabled: Bool) {
-        baseRT_set_timestamps(handle, enabled)
+    /// - Throws: `BaseRTError.reentrantModelCall` if called from within a callback.
+    public func setTimestamps(enabled: Bool) throws {
+        try withHandleLock { baseRT_set_timestamps(handle, enabled) }
+    }
+
+    /// Set the Whisper task: `"transcribe"` (default) or `"translate"`.
+    /// - Throws: `BaseRTError.reentrantModelCall` if called from within a callback,
+    ///   or `BaseRTError.transcribeFailed` on an unknown task / translate with an
+    ///   English-only model.
+    public func setTask(_ task: String) throws {
+        try withHandleLock {
+            if !baseRT_set_task(handle, task) {
+                let err = baseRT_get_error().flatMap { String(cString: $0) } ?? "baseRT_set_task failed"
+                throw BaseRTError.transcribeFailed(err)
+            }
+        }
+    }
+
+    /// Set an initial prompt to bias Whisper decoding (`nil` clears it).
+    /// - Throws: `BaseRTError.reentrantModelCall` if called from within a callback.
+    public func setInitialPrompt(_ text: String?) throws {
+        try withHandleLock { baseRT_set_initial_prompt(handle, text) }
+    }
+
+    /// Condition each 30s window on previous decoded text (default true).
+    /// - Throws: `BaseRTError.reentrantModelCall` if called from within a callback.
+    public func setConditionOnPreviousText(enabled: Bool) throws {
+        try withHandleLock { baseRT_set_condition_on_previous_text(handle, enabled) }
+    }
+
+    /// Language code of the last transcription (detected or requested).
+    /// - Throws: `BaseRTError.reentrantModelCall` if called from within a callback.
+    public func transcribeLanguage() throws -> String {
+        try withHandleLock {
+            guard let cstr = baseRT_transcribe_language(handle) else { return "" }
+            return String(cString: cstr)
+        }
+    }
+
+    /// Duration of the last transcription's source audio in milliseconds
+    /// (the OpenAI verbose_json `duration` field is this value in fractional
+    /// seconds). 0 if no transcription has run.
+    /// - Throws: `BaseRTError.reentrantModelCall` if called from within a callback.
+    public func transcribeAudioDurationMs() throws -> Int {
+        try withHandleLock { Int(baseRT_transcribe_audio_duration_ms(handle)) }
+    }
+
+    /// Per-segment metadata for the last transcription (verbose_json
+    /// surface). Empty if no transcription has run. Segment text is copied
+    /// out, so the returned array stays valid after later transcriptions.
+    /// - Throws: `BaseRTError.reentrantModelCall` if called from within a callback.
+    public func transcribeSegments() throws -> [TranscribeSegment] {
+        try withHandleLock {
+            let n = Int(baseRT_transcribe_segment_count(handle))
+            var segments: [TranscribeSegment] = []
+            segments.reserveCapacity(max(n, 0))
+            var i = 0
+            while i < n {
+                var seg = BaseRTTranscribeSegment()
+                guard baseRT_transcribe_segment(handle, Int32(i), &seg) else { break }
+                let text = seg.text.map { String(cString: $0) } ?? ""
+                segments.append(
+                    TranscribeSegment(
+                        startMs: Int(seg.start_ms),
+                        endMs: Int(seg.end_ms),
+                        text: text,
+                        avgLogprob: seg.avg_logprob,
+                        noSpeechProb: seg.no_speech_prob,
+                        compressionRatio: seg.compression_ratio,
+                        temperature: seg.temperature
+                    ))
+                i += 1
+            }
+            return segments
+        }
     }
 
     // MARK: State management
 
     /// Enable or disable speculative decoding (n-gram prediction).
     /// Only affects greedy (temperature=0) mode.
-    public func setSpeculation(enabled: Bool) {
-        baseRT_set_speculation(handle, enabled)
+    /// - Throws: `BaseRTError.reentrantModelCall` if called from within a callback.
+    public func setSpeculation(enabled: Bool) throws {
+        try withHandleLock { baseRT_set_speculation(handle, enabled) }
     }
 
     /// Reset KV cache and internal state.
-    public func reset() {
-        baseRT_reset(handle)
+    /// - Throws: `BaseRTError.reentrantModelCall` if called from within a callback.
+    public func reset() throws {
+        try withHandleLock { baseRT_reset(handle) }
     }
 
     // MARK: Low-level API
 
     /// Run prefill on tokens, populating the KV cache.
     /// - Returns: The first generated token (argmax of prefill logits).
-    public func prefill(tokens: [UInt32]) -> UInt32 {
-        tokens.withUnsafeBufferPointer { buf in
-            baseRT_prefill(handle, buf.baseAddress, Int32(tokens.count))
+    /// - Throws: `BaseRTError.reentrantModelCall` if called from within a callback.
+    public func prefill(tokens: [UInt32]) throws -> UInt32 {
+        // Serialized against every other handle-touching call (see handleLock).
+        try withHandleLock {
+            tokens.withUnsafeBufferPointer { buf in
+                baseRT_prefill(handle, buf.baseAddress, Int32(tokens.count))
+            }
         }
     }
 
     /// Run one decode step.
     /// - Returns: The sampled token ID.
-    public func decodeStep(tokenID: UInt32, position: Int) -> UInt32 {
-        baseRT_decode_step(handle, tokenID, Int32(position))
+    /// - Throws: `BaseRTError.reentrantModelCall` if called from within a callback.
+    public func decodeStep(tokenID: UInt32, position: Int) throws -> UInt32 {
+        try withHandleLock { baseRT_decode_step(handle, tokenID, Int32(position)) }
     }
 
     /// Chain decode: generate multiple tokens in one GPU submission.
     /// - Returns: Array of generated token IDs.
-    public func chainDecode(firstToken: UInt32, startPosition: Int, count: Int) -> [UInt32] {
-        var out = [UInt32](repeating: 0, count: count)
-        let n = baseRT_chain_decode(handle, firstToken, Int32(startPosition), Int32(count), &out)
-        return Array(out.prefix(Int(n)))
+    /// - Throws: `BaseRTError.reentrantModelCall` if called from within a callback.
+    public func chainDecode(firstToken: UInt32, startPosition: Int, count: Int) throws -> [UInt32] {
+        // Serialized against every other handle-touching call (see handleLock).
+        try withHandleLock {
+            var out = [UInt32](repeating: 0, count: count)
+            let n = baseRT_chain_decode(handle, firstToken, Int32(startPosition), Int32(count), &out)
+            return Array(out.prefix(Int(n)))
+        }
     }
 
     // MARK: Model inspection
 
     /// Number of tensors in the model.
+    /// - Throws: `BaseRTError.reentrantModelCall` if read from within a callback.
     public var tensorCount: Int {
-        Int(baseRT_tensor_count(handle))
+        get throws { try withHandleLock { Int(baseRT_tensor_count(handle)) } }
     }
 
     /// Get the name of a tensor by index.
-    public func tensorName(at index: Int) -> String? {
-        guard let ptr = baseRT_tensor_name(handle, Int32(index)) else { return nil }
-        return String(cString: ptr)
+    /// - Throws: `BaseRTError.reentrantModelCall` if called from within a callback.
+    public func tensorName(at index: Int) throws -> String? {
+        try withHandleLock {
+            guard let ptr = baseRT_tensor_name(handle, Int32(index)) else { return nil }
+            return String(cString: ptr)
+        }
     }
 
     /// Get the dtype code of a tensor by index.
-    public func tensorDtype(at index: Int) -> UInt32 {
-        baseRT_tensor_dtype(handle, Int32(index))
+    /// - Throws: `BaseRTError.reentrantModelCall` if called from within a callback.
+    public func tensorDtype(at index: Int) throws -> UInt32 {
+        try withHandleLock { baseRT_tensor_dtype(handle, Int32(index)) }
     }
 }
 
@@ -644,8 +1018,17 @@ public final class BaseRTModel {
 /// Internal class to bridge Swift closures to C callbacks.
 private final class CallbackContext {
     let callback: (GeneratedToken) -> Bool
-    init(callback: @escaping (GeneratedToken) -> Bool) {
+    /// When non-nil, the trampoline increments this model's thread-local
+    /// callback-depth marker around the USER's closure so a same-thread re-entrant
+    /// model API call throws instead of corrupting/deadlocking the busy handle.
+    /// It is nil for the internal
+    /// AsyncStream yield path, whose closure only does `continuation.yield` and
+    /// never runs user model-reentrant code — flagging it would spuriously reject
+    /// consumers that legitimately call the model between tokens.
+    weak var guardModel: BaseRTModel?
+    init(callback: @escaping (GeneratedToken) -> Bool, guardModel: BaseRTModel?) {
         self.callback = callback
+        self.guardModel = guardModel
     }
 }
 
@@ -659,6 +1042,15 @@ private func cTokenCallback(
     let ctx = Unmanaged<CallbackContext>.fromOpaque(userData).takeUnretainedValue()
     let str = text.map { String(cString: $0) } ?? ""
     let token = GeneratedToken(tokenID: tokenID, text: str)
+    // Only the direct user-callback paths supply a guardModel; the AsyncStream
+    // yield path leaves it nil and runs unguarded.
+    guard let model = ctx.guardModel else {
+        return ctx.callback(token)
+    }
+    // Mark THIS (worker) thread as inside the model's callback so a same-thread
+    // re-entrant model call throws; unrelated threads are unaffected.
+    model.enterCallbackScope()
+    defer { model.exitCallbackScope() }
     return ctx.callback(token)
 }
 
@@ -667,8 +1059,14 @@ private func cTokenCallback(
 /// Internal class to bridge Swift closures to C segment callbacks.
 private final class SegmentCallbackContext {
     let callback: (TranscriptSegment) -> Bool
-    init(callback: @escaping (TranscriptSegment) -> Bool) {
+    /// Always non-nil for the transcription paths — the user's `onSegment` runs
+    /// synchronously inside the native call, so the trampoline increments the
+    /// model's thread-local callback-depth marker around it to reject same-thread
+    /// re-entrant model calls.
+    weak var guardModel: BaseRTModel?
+    init(callback: @escaping (TranscriptSegment) -> Bool, guardModel: BaseRTModel?) {
         self.callback = callback
+        self.guardModel = guardModel
     }
 }
 
@@ -683,10 +1081,76 @@ private func cSegmentCallback(
     let ctx = Unmanaged<SegmentCallbackContext>.fromOpaque(userData).takeUnretainedValue()
     let str = text.map { String(cString: $0) } ?? ""
     let segment = TranscriptSegment(startMs: Int(startMs), endMs: Int(endMs), text: str)
+    guard let model = ctx.guardModel else {
+        return ctx.callback(segment)
+    }
+    // Mark THIS (worker) thread as inside the model's callback so a same-thread
+    // re-entrant model call throws; unrelated threads are unaffected.
+    model.enterCallbackScope()
+    defer { model.exitCallbackScope() }
     return ctx.callback(segment)
 }
 
 // MARK: - AsyncSequence support for streaming generation
+
+/// Thread-safe cancellation flag shared between the async iterator and the
+/// background generation thread.
+private final class CancellationFlag {
+    private let lock = NSLock()
+    private var cancelled = false
+
+    func cancel() {
+        lock.lock()
+        cancelled = true
+        lock.unlock()
+    }
+
+    var isCancelled: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return cancelled
+    }
+}
+
+/// Ties cancellation to the lifetime of a single `AsyncIterator`.
+///
+/// `AsyncIterator` is a value type and therefore has no `deinit`, while
+/// `AsyncStream.onTermination` is NOT invoked when a consumer leaves a
+/// `for await` loop via a plain `break` (the generation closure keeps the
+/// continuation alive, so the stream never "terminates"). Holding the
+/// cancellation flag inside this reference type — strongly referenced by the
+/// iterator (and shared across its value copies) but deliberately NOT captured
+/// by the background generation closure — makes cancellation fire from the
+/// iterator's own deallocation: once the last iterator copy is dropped (break,
+/// task cancellation, or normal exhaustion), this object deinitializes and
+/// flips the flag, halting generation instead of letting it run to `maxTokens`
+/// and overlap a subsequent call on the non-thread-safe model.
+private final class IteratorCancellation {
+    let flag: CancellationFlag
+    init(_ flag: CancellationFlag) { self.flag = flag }
+    deinit { flag.cancel() }
+}
+
+/// Shared, thread-safe once-gate for the deferred generation start.
+///
+/// `AsyncIterator` is a value type, so copying it before the first `next()`
+/// would duplicate a plain `started` flag and let two copies each start
+/// generation, launching overlapping `baseRT_generate` calls on the
+/// non-thread-safe model. Holding the flag in this reference type, captured by
+/// all iterator copies, guarantees generation starts exactly once.
+private final class StartGate {
+    private let lock = NSLock()
+    private var started = false
+
+    /// Returns true exactly once (for the first caller); false thereafter.
+    func tryStart() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        if started { return false }
+        started = true
+        return true
+    }
+}
 
 /// An asynchronous sequence that yields tokens as they are generated.
 @available(macOS 10.15, iOS 13.0, *)
@@ -712,13 +1176,20 @@ public struct TokenStream: AsyncSequence {
     }
 
     public struct AsyncIterator: AsyncIteratorProtocol {
-        private let stream: TokenStream
-        private var started = false
+        // Shared across all copies of this value-type iterator so generation
+        // starts exactly once, even if the iterator is copied before next().
+        private let startGate = StartGate()
         private var continuation: AsyncStream<GeneratedToken>.Iterator
         private let asyncStream: AsyncStream<GeneratedToken>
+        private let startGeneration: () -> Void
+        // Strongly held by every copy of this value-type iterator; its deinit
+        // (fired when the last copy drops) flips the cancellation flag. This is
+        // the primary cancellation path, since onTermination does not run on a
+        // plain `break`. It is NOT captured by `startGeneration`, so the running
+        // worker cannot keep it alive and prevent that deinit.
+        private let lifetime: IteratorCancellation
 
         init(stream: TokenStream) {
-            self.stream = stream
             var capturedContinuation: AsyncStream<GeneratedToken>.Continuation!
             self.asyncStream = AsyncStream { continuation in
                 capturedContinuation = continuation
@@ -732,23 +1203,70 @@ public struct TokenStream: AsyncSequence {
             let sampling = stream.sampling
             let isContinuation = stream.isContinuation
 
-            // Run generation on a background thread to avoid blocking the caller.
-            DispatchQueue.global(qos: .userInitiated).async {
-                let callback: (GeneratedToken) -> Bool = { token in
-                    cont.yield(token)
-                    return true
+            // Flipped when the consumer stops iterating (break out of
+            // `for await`, task cancellation, iterator deallocation) so the
+            // token callback halts generation instead of running to maxTokens.
+            let cancelled = CancellationFlag()
+            // Own the flag from the iterator's lifetime: its deinit cancels on a
+            // plain `break`, which onTermination below does not observe. The
+            // onTermination hook remains as a secondary path (e.g. finish()).
+            self.lifetime = IteratorCancellation(cancelled)
+            cont.onTermination = { _ in cancelled.cancel() }
+
+            // Deferred until the first next() call so that merely creating an
+            // iterator does not kick off GPU generation.
+            self.startGeneration = {
+                // Run generation on a background thread to avoid blocking the caller.
+                DispatchQueue.global(qos: .userInitiated).async {
+                    let callback: (GeneratedToken) -> Bool = { token in
+                        if cancelled.isCancelled { return false }
+                        cont.yield(token)
+                        return !cancelled.isCancelled
+                    }
+                    // generateCore acquires the model's handleLock and holds it
+                    // for the ENTIRE native call. If a prior worker is still
+                    // winding down (e.g. the consumer just broke and immediately
+                    // started this stream), this call blocks here on the
+                    // background thread until that worker's baseRT_generate
+                    // returns and releases the lock — the consumer meanwhile
+                    // simply awaits the first yielded token. Two workers thus
+                    // never overlap on the non-thread-safe handle.
+                    //
+                    // guardCallback: false — this internal callback only does
+                    // `cont.yield` and never runs user model-reentrant code, so
+                    // it must NOT mark the thread-local callback-depth (that would
+                    // spuriously reject consumers that legitimately call the model
+                    // between tokens).
+                    //
+                    // shouldCancelBeforeGenerate — checked by generateCore AFTER
+                    // it has acquired the handle lock (serialization ownership)
+                    // and IMMEDIATELY BEFORE the native call. If the consumer's
+                    // task was already cancelled while this worker sat queued
+                    // behind another in-flight stream for the lock, generateCore
+                    // throws `.cancelledBeforeGeneration` instead of running
+                    // native prompt prefill + generation — so a long prompt does
+                    // NOT burn GPU time after cancellation.
+                    //
+                    // `try?`: generateCore throws only `.reentrantModelCall`
+                    // (impossible here — this top-level worker sets no callback
+                    // flag) or `.cancelledBeforeGeneration` (the skip above);
+                    // both simply end the stream cleanly. Either way `cont.finish()`
+                    // completes the continuation exactly once, yielding an empty /
+                    // cancelled stream when generation was skipped.
+                    _ = try? model.generateCore(
+                        tokens: tokens, maxTokens: maxTokens, sampling: sampling,
+                        onToken: callback, isContinuation: isContinuation, guardCallback: false,
+                        shouldCancelBeforeGenerate: { cancelled.isCancelled })
+                    cont.finish()
                 }
-                if isContinuation {
-                    model.generateContinue(tokens: tokens, maxTokens: maxTokens, sampling: sampling, onToken: callback)
-                } else {
-                    model.generate(tokens: tokens, maxTokens: maxTokens, sampling: sampling, onToken: callback)
-                }
-                cont.finish()
             }
         }
 
         public mutating func next() async -> GeneratedToken? {
-            await continuation.next()
+            if startGate.tryStart() {
+                startGeneration()
+            }
+            return await continuation.next()
         }
     }
 }
@@ -764,6 +1282,16 @@ extension BaseRTModel {
     ///     print(token.text, terminator: "")
     /// }
     /// ```
+    ///
+    /// Consuming the stream (the `for await` body above) is safe: tokens are
+    /// delivered through an `AsyncStream` continuation, so the consumer runs on
+    /// its own task and never re-enters the model from inside the generation
+    /// worker's callback. Calling this same model from the consumer between
+    /// tokens is likewise fine — the stream's internal yield callback does NOT
+    /// arm the re-entrancy guard, so such calls simply serialize on the handle
+    /// lock. (The guard only fires for a USER `onToken` / `onSegment` closure in
+    /// the direct `generate` / `transcribe` paths; see
+    /// `generate(tokens:maxTokens:...)`.)
     public func stream(
         tokens: [UInt32],
         maxTokens: Int,

--- a/bindings/swift/Sources/BaseRT/BaseRTEngine.swift
+++ b/bindings/swift/Sources/BaseRT/BaseRTEngine.swift
@@ -37,36 +37,60 @@ public enum BaseRTEngine {
 }
 
 // MARK: - Additional model surface
+//
+// Every method below touches the non-thread-safe C `handle`, so — exactly like
+// the core surface in `BaseRT.swift` — each goes through `withHandleLock`, which
+// rejects re-entry from a token/segment callback (throwing
+// `BaseRTError.reentrantModelCall`) before acquiring the non-recursive
+// `handleLock`. Ordinary concurrent callers block-and-wait on the lock as usual.
+// Because the guard can throw, these APIs are `throws` too.
 
 extension BaseRTModel {
 
     /// Total tokens currently in the KV cache.
-    public var positionTokens: Int { Int(baseRT_get_position(handle)) }
+    /// - Throws: `BaseRTError.reentrantModelCall` if read from within a callback.
+    public var positionTokens: Int {
+        get throws { try withHandleLock { Int(baseRT_get_position(handle)) } }
+    }
 
     /// Primary end-of-sequence token id.
-    public var eosTokenID: UInt32 { baseRT_eos_token_id(handle) }
+    /// - Throws: `BaseRTError.reentrantModelCall` if read from within a callback.
+    public var eosTokenID: UInt32 {
+        get throws { try withHandleLock { baseRT_eos_token_id(handle) } }
+    }
 
     /// BOS / EOS token strings (as substituted in HF chat templates).
-    public var bosToken: String { cString(baseRT_bos_token(handle)) }
-    public var eosToken: String { cString(baseRT_eos_token(handle)) }
+    /// - Throws: `BaseRTError.reentrantModelCall` if read from within a callback.
+    public var bosToken: String {
+        get throws { try withHandleLock { cString(baseRT_bos_token(handle)) } }
+    }
+    /// - Throws: `BaseRTError.reentrantModelCall` if read from within a callback.
+    public var eosToken: String {
+        get throws { try withHandleLock { cString(baseRT_eos_token(handle)) } }
+    }
 
     /// Raw Jinja chat template folded in from the `.base` bundle (empty if none).
-    public var chatTemplateJinja: String { cString(baseRT_chat_template_jinja(handle)) }
+    /// - Throws: `BaseRTError.reentrantModelCall` if read from within a callback.
+    public var chatTemplateJinja: String {
+        get throws { try withHandleLock { cString(baseRT_chat_template_jinja(handle)) } }
+    }
 
     /// Stateless single-token decode (does not advance the incremental decoder).
-    public func decodeTokenStatic(_ tokenID: UInt32) -> String {
-        cString(baseRT_decode_token_static(handle, tokenID))
+    /// - Throws: `BaseRTError.reentrantModelCall` if called from within a callback.
+    public func decodeTokenStatic(_ tokenID: UInt32) throws -> String {
+        try withHandleLock { cString(baseRT_decode_token_static(handle, tokenID)) }
     }
 
     /// Generate and return the full decoded text in one call.
+    /// - Throws: `BaseRTError.reentrantModelCall` if called from within a callback.
     @discardableResult
     public func generateText(
         tokens: [UInt32],
         maxTokens: Int,
         sampling: SamplingConfig = SamplingConfig()
-    ) -> String {
+    ) throws -> String {
         var out = ""
-        _ = generate(tokens: tokens, maxTokens: maxTokens, sampling: sampling) { tok in
+        _ = try generate(tokens: tokens, maxTokens: maxTokens, sampling: sampling) { tok in
             out += tok.text
             return true
         }
@@ -76,32 +100,40 @@ extension BaseRTModel {
     // MARK: Multimodal
 
     /// Number of image placeholder tokens the vision tower emits for an image.
-    public func imageTokenCount(imagePath: String) -> Int {
-        Int(baseRT_image_num_tokens(handle, imagePath))
+    /// - Throws: `BaseRTError.reentrantModelCall` if called from within a callback.
+    public func imageTokenCount(imagePath: String) throws -> Int {
+        try withHandleLock { Int(baseRT_image_num_tokens(handle, imagePath)) }
     }
 
     /// Multimodal prefill: run the vision tower on `imagePath`, splice features
     /// at image-token positions, then prefill. Returns the first generated token
     /// (0 on error — check `BaseRTEngine.lastError`).
-    public func prefillImage(tokens: [UInt32], imagePath: String) -> UInt32 {
-        tokens.withUnsafeBufferPointer { buf in
-            baseRT_prefill_image(handle, buf.baseAddress, Int32(tokens.count), imagePath)
+    /// - Throws: `BaseRTError.reentrantModelCall` if called from within a callback.
+    public func prefillImage(tokens: [UInt32], imagePath: String) throws -> UInt32 {
+        try withHandleLock {
+            tokens.withUnsafeBufferPointer { buf in
+                baseRT_prefill_image(handle, buf.baseAddress, Int32(tokens.count), imagePath)
+            }
         }
     }
 
     /// Number of audio placeholder tokens for `nSamples` of 16 kHz mono PCM.
-    public func audioTokenCount(nSamples: Int) -> Int {
-        Int(baseRT_audio_num_tokens(handle, Int32(nSamples)))
+    /// - Throws: `BaseRTError.reentrantModelCall` if called from within a callback.
+    public func audioTokenCount(nSamples: Int) throws -> Int {
+        try withHandleLock { Int(baseRT_audio_num_tokens(handle, Int32(nSamples))) }
     }
 
     /// Audio prefill: run the Conformer encoder on PCM (16 kHz mono Float32),
     /// splice features at audio-token positions, then prefill.
-    public func prefillAudio(tokens: [UInt32], pcm: [Float]) -> UInt32 {
-        tokens.withUnsafeBufferPointer { tBuf in
-            pcm.withUnsafeBufferPointer { pBuf in
-                baseRT_prefill_audio(
-                    handle, tBuf.baseAddress, Int32(tokens.count),
-                    pBuf.baseAddress, Int32(pcm.count))
+    /// - Throws: `BaseRTError.reentrantModelCall` if called from within a callback.
+    public func prefillAudio(tokens: [UInt32], pcm: [Float]) throws -> UInt32 {
+        try withHandleLock {
+            tokens.withUnsafeBufferPointer { tBuf in
+                pcm.withUnsafeBufferPointer { pBuf in
+                    baseRT_prefill_audio(
+                        handle, tBuf.baseAddress, Int32(tokens.count),
+                        pBuf.baseAddress, Int32(pcm.count))
+                }
             }
         }
     }
@@ -109,38 +141,46 @@ extension BaseRTModel {
     // MARK: KV-cache state
 
     /// Truncate the KV cache to `toPosition` tokens (drop everything after).
-    public func rollback(toPosition: Int) {
-        baseRT_rollback(handle, Int32(toPosition))
+    /// - Throws: `BaseRTError.reentrantModelCall` if called from within a callback.
+    public func rollback(toPosition: Int) throws {
+        try withHandleLock { baseRT_rollback(handle, Int32(toPosition)) }
     }
 
     /// Persist the current KV-cache state to `path`. Returns 0 on success.
+    /// - Throws: `BaseRTError.reentrantModelCall` if called from within a callback.
     @discardableResult
-    public func saveState(path: String) -> Int32 {
-        baseRT_save_state(handle, path)
+    public func saveState(path: String) throws -> Int32 {
+        try withHandleLock { baseRT_save_state(handle, path) }
     }
 
     /// Restore KV-cache state previously written by `saveState`. Returns 0 on success.
+    /// - Throws: `BaseRTError.reentrantModelCall` if called from within a callback.
     @discardableResult
-    public func loadState(path: String) -> Int32 {
-        baseRT_load_state(handle, path)
+    public func loadState(path: String) throws -> Int32 {
+        try withHandleLock { baseRT_load_state(handle, path) }
     }
 
     // MARK: LoRA
 
     /// Install a LoRA adapter (`.base` bundle). Replaces any active adapter.
     /// Returns 0 on success, negative on failure.
+    /// - Throws: `BaseRTError.reentrantModelCall` if called from within a callback.
     @discardableResult
-    public func loadLoRA(path: String) -> Int32 {
-        baseRT_lora_load(handle, path)
+    public func loadLoRA(path: String) throws -> Int32 {
+        try withHandleLock { baseRT_lora_load(handle, path) }
     }
 
     /// Detach the active LoRA adapter, if any.
-    public func unloadLoRA() {
-        baseRT_lora_unload(handle)
+    /// - Throws: `BaseRTError.reentrantModelCall` if called from within a callback.
+    public func unloadLoRA() throws {
+        try withHandleLock { baseRT_lora_unload(handle) }
     }
 
     /// Active adapter id (the path it was loaded from), or "" when none.
-    public var loraID: String { cString(baseRT_lora_id(handle)) }
+    /// - Throws: `BaseRTError.reentrantModelCall` if read from within a callback.
+    public var loraID: String {
+        get throws { try withHandleLock { cString(baseRT_lora_id(handle)) } }
+    }
 
     // MARK: helpers
 

--- a/bindings/swift/Sources/CBaseRT/include/baseRT.h
+++ b/bindings/swift/Sources/CBaseRT/include/baseRT.h
@@ -64,7 +64,7 @@ extern "C" {
 
 #define BASERT_VERSION_MAJOR 0
 #define BASERT_VERSION_MINOR 2
-#define BASERT_VERSION_PATCH 0
+#define BASERT_VERSION_PATCH 1
 
 /// Compile-time version, packed as `(MAJOR<<16) | (MINOR<<8) | PATCH`.
 /// Useful for `#if BASERT_VERSION >= 0x000200` feature checks.
@@ -93,6 +93,37 @@ typedef void *baseRT_model_t;
 /// Returns NULL on failure.
 baseRT_model_t baseRT_load_model(const char *model_path, const char *kernel_library_path, int max_context);
 
+/// Load a model with per-call options instead of the process-wide
+/// baseRT_set_* pre-load setters. `opts` may be NULL (identical to
+/// baseRT_load_model); otherwise set opts->struct_size =
+/// sizeof(BaseRTLoadOptions) and zero any field you want left at its default
+/// (see BaseRTLoadOptions in types.h). Loads through this entry point are
+/// serialized against each other; the legacy globals are untouched from the
+/// caller's point of view (saved, applied for the load, restored). A
+/// concurrent plain baseRT_load_model on another thread races the applied
+/// values exactly as it would race the legacy setters — serialize loads if
+/// you mix the two forms.
+baseRT_model_t baseRT_load_model_ex(const char *model_path, const char *kernel_library_path, int max_context,
+                                    const BaseRTLoadOptions *opts);
+
+/// Capability flags reported by baseRT_capabilities(). A scheduler should
+/// branch on these instead of probing entry points for BASERT_ERR_UNSUPPORTED
+/// or inferring support from BaseRTModelConfig fields.
+enum {
+    BASERT_CAP_PAGED_KV = 1u << 0,      ///< loaded with paged KV (sequences, prefix seeding)
+    BASERT_CAP_SEQUENCES = 1u << 1,     ///< baseRT_sequence_create works: continuous batching
+    BASERT_CAP_HOST_LOGITS = 1u << 2,   ///< baseRT_batch_step_fused_logits + read_batch_logits work
+    BASERT_CAP_PREFIX_CACHE = 1u << 3,  ///< RadixCache prefix reuse is active
+    BASERT_CAP_GDN_SNAPSHOT = 1u << 4,  ///< hybrid-GDN recurrent-state snapshot/restore
+};
+
+/// What this loaded model supports, as BASERT_CAP_* flags. Pure query: no GPU
+/// work, no probe sequences, never touches the error state. Values are fixed
+/// at load time. When a capability is absent and the reason matters (e.g. an
+/// operator-facing "continuous batching disabled because ..." message), call
+/// the gated entry point once and read baseRT_get_error().
+uint32_t baseRT_capabilities(baseRT_model_t model);
+
 /// Override the KV cache element width for the next baseRT_load_model call.
 ///   bits = 0  → auto (per-model default; Q8_0 when head_dim%32==0)
 ///   bits = 8  → force Q8_0 K and V slabs (1.88x smaller; tiny precision cost)
@@ -103,7 +134,7 @@ void baseRT_set_kv_bits(int bits);
 
 /// Enable engine diagnostics (RoPE/tokenizer/GPU/architecture dumps, the
 /// per-token dispatch-command count, "Warming up"). Off by default so end
-/// users see only model output. Also honored via the BASERT_VERBOSE env var.
+/// users see only model output.
 void baseRT_set_verbose(int on);
 
 /// Toggle paged-KV mode for the next baseRT_load_model call.
@@ -153,6 +184,23 @@ void baseRT_set_paged_weights(int mode);
 /// Process-wide; read per decode step.
 void baseRT_set_baked_decode(int enable);
 
+/// CUDA decode-replay strategy for fused batch decode ticks.
+///   mode = 2 → stream capture (default): capture the live walk as a CUDA
+///     graph on a shape's second sighting; replay is numerically identical
+///     to the live tick it captured.
+///   mode = 1 → cmd-table replay (experiment; measured a net loss on GB10
+///     serving — see batch_step_fused_common).
+///   mode = 0 → neither: fused ticks run live (no capture, no cmd-table
+///     replay).
+/// Governs ONLY the CUDA fused-tick replay strategy. The baked DispatchTable
+/// fast path for pure-decode ticks is a separate mechanism with its own
+/// switch — baseRT_set_baked_decode(0) — matching the two knobs' historical
+/// independence. Process-wide; the fused decode paths latch the mode on
+/// first use, so set it before the first decode step. Other values are
+/// ignored. No effect on the Metal backend. (Replaces the
+/// BASERT_FUSED_BUCKETS / BASERT_STREAM_CAPTURE env gates.)
+void baseRT_set_decode_replay(int mode);
+
 /// GPU-wait timeout in milliseconds (Metal backend).
 ///   ms > 0   → (default: 300000, i.e. 5 min) return a loggable error if a
 ///     committed command buffer doesn't reach a terminal status in time. The
@@ -160,8 +208,7 @@ void baseRT_set_baked_decode(int enable);
 ///     reset/reboot reclaims it). Chosen far above any legitimate single
 ///     command buffer so only a real wedge trips it.
 ///   ms = 0   → block indefinitely in the GPU wait (opt out of the bound).
-/// No-op on non-Metal backends. Process-wide; read once per wait. The initial
-/// value also honors the BASERT_GPU_WAIT_TIMEOUT_MS environment variable.
+/// No-op on non-Metal backends. Process-wide; read once per wait.
 void baseRT_set_gpu_wait_timeout_ms(double ms);
 
 /// Free all resources associated with a model.
@@ -291,26 +338,9 @@ BaseRTGenerationStats baseRT_sequence_generate_continue(baseRT_sequence_t seq, c
 /// Release the sequence's blocks back to the pool and free the handle.
 void baseRT_sequence_free(baseRT_sequence_t seq);
 
-/// Fused batch step with per-sequence trailing PAD counts (serving grid
-/// alignment): counts[i] includes pads[i] throwaway tokens whose rows are
-/// computed but whose argmax row is skipped (the output token comes from the
-/// last REAL row). The caller must roll each padded sequence's KV back by
-/// pads[i] after the call (baseRT_sequence_rollback). Greedy only.
-int baseRT_batch_step_fused_pads(baseRT_model_t model, baseRT_sequence_t *seqs, int n_seqs, const uint32_t *in_tokens,
-                                 const int *in_token_counts, const int *pads, uint32_t *out_tokens);
-
-/// Warm the batched-decode fast paths for batch sizes up to `max_batch`:
-/// each B runs two throwaway pure-decode ticks so shape-keyed caches (baked
-/// dispatch tables, stream-captured CUDA graphs, cuBLAS plans) are built at
-/// startup instead of on the first real requests — the same boot-time graph
-/// warmup vLLM performs. Requires --paged-kv; call after load, before serving.
-int baseRT_batch_warmup(baseRT_model_t model, int max_batch);
-
-/// Roll a sequence's KV state back to `length` tokens, returning any blocks
-/// past that point to the pool. `length` must be <= the current length; 0
-/// resets the sequence to empty. Used by the serving engine's shape-padding
-/// dummy lanes (their KV is discarded after every tick).
-int baseRT_sequence_rollback(baseRT_sequence_t seq, int length);
+// baseRT_batch_step_fused_pads / baseRT_batch_warmup /
+// baseRT_sequence_rollback are declared once, below with the rest of the
+// batched-decode API (their doc blocks had already started drifting apart).
 
 /// Batched decode: drives ONE batched decode step across N sequences. Each
 /// sequence writes its `new_tokens[i]` to its own KV cache slot, and attention
@@ -469,6 +499,55 @@ int baseRT_batch_step_fused_logits(baseRT_model_t model, baseRT_sequence_t *seqs
 /// `n_seqs` must match the batch of the preceding step and be <= max_batch_size.
 int baseRT_read_batch_logits(baseRT_model_t model, int n_seqs, void *out_logits_f16);
 
+// === Host-side logits-row operations ===
+//
+// Companions to baseRT_read_batch_logits for schedulers that sample on the
+// host: they encapsulate the engine's logits element type and row layout so
+// the caller never casts raw buffers or re-implements dtype-sensitive math
+// (which must stay bit-compatible with the engine's own greedy/sampled paths).
+// A "row" below is one sequence's logits inside the buffer written by
+// baseRT_read_batch_logits: row `s` starts at byte offset
+// `s * baseRT_batch_logits_stride(model)`.
+
+/// Bytes between consecutive sequence rows in the baseRT_read_batch_logits
+/// output buffer (also the size of one row). Size the readback buffer as
+/// `n_seqs * stride` bytes. Returns 0 on a null model.
+size_t baseRT_batch_logits_stride(baseRT_model_t model);
+
+/// Apply a grammar bitmask (from baseRT_grammar_fill_bitmask; a SET bit =
+/// allowed token) to one logits row IN PLACE: every disallowed token's logit
+/// becomes -inf, so subsequent sampling and logprob reads on the row see the
+/// constrained distribution. Returns BASERT_OK or an error code.
+int baseRT_mask_logits_row(baseRT_model_t model, void *row, const int32_t *bitmask);
+
+/// Run the full CPU sampling pipeline (temperature / top-k / top-p / min-p /
+/// repetition + presence + frequency penalties / logit_bias) over one logits
+/// row. `prev_tokens`/`n_prev` feed the repetition penalties;
+/// `repeat_window` bounds how many trailing prev_tokens are penalized (0 =
+/// all). When cfg->seed != 0 the sampling RNG is reseeded with
+/// cfg->seed + seed_offset first — pass the per-sequence generated-token
+/// count as seed_offset for deterministic per-lane streams under batch
+/// interleaving. Returns the sampled token id (0 with the error state set on
+/// invalid arguments).
+uint32_t baseRT_sample_logits_row(baseRT_model_t model, const void *row, const BaseRTSamplingConfig *cfg,
+                                  const uint32_t *prev_tokens, int n_prev, int repeat_window, uint32_t seed_offset);
+
+/// Lowest-index argmax over one logits row — the exact tie-break of the GPU
+/// argmax and the CPU greedy fast path, which sampling with top_k=1 does NOT
+/// guarantee (equal-logit ties are common with f16 logits). Use this for
+/// greedy lanes in a host-sampled batch. Returns 0 with the error state set
+/// on invalid arguments.
+uint32_t baseRT_argmax_logits_row(baseRT_model_t model, const void *row);
+
+/// Log-softmax over one logits row: writes the chosen token's logprob to
+/// *out_token_logprob and the top `top_k` alternatives (ids + logprobs,
+/// descending) to out_ids/out_logprobs, which must hold top_k entries.
+/// top_k = 0 computes only the chosen token's logprob. Returns the number of
+/// alternatives written, or < 0 with the error state set on invalid
+/// arguments.
+int baseRT_logits_row_logprobs(baseRT_model_t model, const void *row, uint32_t token, int top_k,
+                               float *out_token_logprob, uint32_t *out_ids, float *out_logprobs);
+
 // === Prefix cache — scheduler-driven primitives ===
 //
 // A scheduler (e.g. the continuous-batching BatchEngine) reuses the KV of a
@@ -507,8 +586,11 @@ BaseRTPrefixMatch baseRT_prefix_match(baseRT_model_t model, const uint32_t *toke
 
 /// Seed a freshly-created, empty sequence with the shared blocks from a match
 /// so it reuses their KV instead of re-prefilling. `n_tokens` must equal
-/// `n_blocks * page_size`. Returns BASERT_OK, or an error if the model isn't
-/// paged / the sequence isn't empty.
+/// `n_blocks * page_size`. An empty match (n_blocks == 0 && n_tokens == 0) is
+/// a successful no-op; any other zero/null combination is rejected with
+/// BASERT_ERR_INVALID_ARGUMENT (nothing was adopted — release the match).
+/// Returns BASERT_OK, or an error if the model isn't paged / the sequence
+/// isn't empty.
 int baseRT_sequence_seed_prefix(baseRT_sequence_t seq, const int *blocks, int n_blocks, int n_tokens);
 
 /// Paged-KV block (page) size in tokens for this model, or 0 when the model
@@ -634,7 +716,8 @@ BaseRTGenerationStats baseRT_generate_grammar_continue(baseRT_model_t model, con
 /// Runs each layer in its own command buffer for accurate GPU timing.
 /// Much slower than normal decode — use only for profiling.
 /// timing_out: array of (n_layers + 3) floats [embedding, norm, layer0..N-1, logit, argmax]
-/// Returns number of timing entries written.
+/// Returns number of timing entries written, or -1 on a failed step
+/// (details via baseRT_get_error).
 int baseRT_profile_decode_step(baseRT_model_t model, uint32_t token_id, int position, float *timing_out,
                                int max_entries);
 
@@ -936,10 +1019,7 @@ const char *baseRT_eos_token(baseRT_model_t model);
 /// other token-id consumers stop on). Returns 0 on a null handle.
 uint32_t baseRT_eos_token_id(baseRT_model_t model);
 
-/// Max prompt tokens the fused (varlen) prefill can process in one packed batch.
-/// The continuous-batching engine caps per-tick admitted prompt tokens by this
-/// so a burst of long prompts doesn't overflow the packed prefill. 0 on null.
-int baseRT_max_prefill_chunk(baseRT_model_t model);
+// (baseRT_max_prefill_chunk is declared once, with the batched-decode API.)
 
 // === Token counting ===
 
@@ -981,6 +1061,54 @@ const char *baseRT_transcribe_stream(baseRT_model_t model, const char *wav_path,
 /// When enabled (default): produces [start --> end] text segments with seeking.
 /// When disabled: faster greedy decode, plain text output.
 void baseRT_set_timestamps(baseRT_model_t model, bool enabled);
+
+/// Set the Whisper task: "transcribe" (default) or "translate" (any-to-English).
+/// NULL resets to "transcribe". Returns false (with baseRT_get_error set) on an
+/// unknown task string, or on "translate" with an English-only model.
+bool baseRT_set_task(baseRT_model_t model, const char *task);
+
+/// Set an initial prompt for Whisper transcription (reference `initial_prompt`):
+/// tokenized and fed after <|startofprev|> ahead of the first window's prompt,
+/// biasing the decode (names, spellings, style). NULL or "" clears it.
+/// On models whose tokenizer cannot encode text (legacy GGML whisper files
+/// without BPE merges) the prompt is ignored with a warning at transcribe time.
+void baseRT_set_initial_prompt(baseRT_model_t model, const char *text);
+
+/// condition_on_previous_text (default true, reference semantics): feed each
+/// window the previous windows' decoded text after <|startofprev|>. Disable if
+/// the model gets stuck in repetition loops on your audio.
+void baseRT_set_condition_on_previous_text(baseRT_model_t model, bool enabled);
+
+/// Language code of the LAST transcription: the detected code when the request
+/// language was NULL/""/"auto", otherwise the requested code. Empty string if
+/// no transcription has run. Valid until the next transcription or model free.
+const char *baseRT_transcribe_language(baseRT_model_t model);
+
+/// Duration of the LAST transcription's source audio, in milliseconds
+/// (n_samples at 16 kHz — the OpenAI verbose_json `duration` field is this
+/// value in fractional seconds). 0 if no transcription has run.
+int baseRT_transcribe_audio_duration_ms(baseRT_model_t model);
+
+/// Per-segment metadata for the LAST transcription (verbose_json surface).
+/// avg_logprob / no_speech_prob / compression_ratio / temperature are
+/// window-level values applied to every segment decoded in that 30 s window
+/// (the reference computes them per-decode-result; window-level is this
+/// engine's documented approximation for chain-decoded tokens).
+typedef struct {
+    int start_ms;
+    int end_ms;
+    const char *text;  // valid until the next transcription or model free
+    float avg_logprob;
+    float no_speech_prob;
+    float compression_ratio;
+    float temperature;
+} BaseRTTranscribeSegment;
+
+/// Number of segments produced by the last transcription (0 if none).
+int baseRT_transcribe_segment_count(baseRT_model_t model);
+
+/// Fetch one segment of the last transcription. Returns false on bad index.
+bool baseRT_transcribe_segment(baseRT_model_t model, int index, BaseRTTranscribeSegment *out);
 
 /// Check if loaded model is a Whisper model.
 bool baseRT_is_whisper(baseRT_model_t model);

--- a/bindings/swift/Sources/CBaseRT/include/types.h
+++ b/bindings/swift/Sources/CBaseRT/include/types.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <stddef.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -240,6 +241,23 @@ typedef struct {
     float prefill_tokens_per_sec;
     float decode_tokens_per_sec;
 } BaseRTGenerationStats;
+
+/// Per-load configuration for baseRT_load_model_ex. Replaces the process-wide
+/// baseRT_set_* pre-load setters with values scoped to one load call, so a
+/// lazily-reloading host (e.g. a server's model registry) doesn't depend on
+/// globals set once at startup. Zero-initialize (`BaseRTLoadOptions opts = {0}`
+/// / value-init) and set `struct_size = sizeof(BaseRTLoadOptions)`; every
+/// zero field keeps today's default, so a zeroed struct behaves exactly like
+/// plain baseRT_load_model with no setters called.
+typedef struct {
+    size_t struct_size;      ///< must be sizeof(BaseRTLoadOptions); ABI guard
+    int kv_bits;             ///< 0 default, or 4 / 8 / 16 / 84 (84 = K@Q8, V@Q4)
+    int paged_kv;            ///< 0 default (off), 1 on
+    int max_batch_size;      ///< 0 default (1), else >= 1 decode lanes
+    int prefix_cache;        ///< 0 default (off), 1 on (needs paged_kv)
+    int prefill_chunk;       ///< 0 per-chip default, else tokens per prefill pass
+    int paged_weights_mode;  ///< 0 auto-retry on GPU-OOM, 1 force paged, 2 fail hard
+} BaseRTLoadOptions;
 
 #ifdef __cplusplus
 }

--- a/bindings/swift/Tests/BaseRTTests/BaseRTTests.swift
+++ b/bindings/swift/Tests/BaseRTTests/BaseRTTests.swift
@@ -131,7 +131,7 @@ final class BaseRTTests: XCTestCase {
         let model = try BaseRTModel(modelPath: modelPath, kernelLibraryPath: nil)
         let tokens = try model.encode(text: "The capital of France is")
         XCTAssertFalse(tokens.isEmpty)
-        let text = model.generateText(tokens: tokens, maxTokens: 8)
+        let text = try model.generateText(tokens: tokens, maxTokens: 8)
         XCTAssertFalse(text.isEmpty)
     }
 }

--- a/include/baseRT/baseRT.h
+++ b/include/baseRT/baseRT.h
@@ -64,7 +64,7 @@ extern "C" {
 
 #define BASERT_VERSION_MAJOR 0
 #define BASERT_VERSION_MINOR 2
-#define BASERT_VERSION_PATCH 0
+#define BASERT_VERSION_PATCH 1
 
 /// Compile-time version, packed as `(MAJOR<<16) | (MINOR<<8) | PATCH`.
 /// Useful for `#if BASERT_VERSION >= 0x000200` feature checks.
@@ -93,6 +93,37 @@ typedef void *baseRT_model_t;
 /// Returns NULL on failure.
 baseRT_model_t baseRT_load_model(const char *model_path, const char *kernel_library_path, int max_context);
 
+/// Load a model with per-call options instead of the process-wide
+/// baseRT_set_* pre-load setters. `opts` may be NULL (identical to
+/// baseRT_load_model); otherwise set opts->struct_size =
+/// sizeof(BaseRTLoadOptions) and zero any field you want left at its default
+/// (see BaseRTLoadOptions in types.h). Loads through this entry point are
+/// serialized against each other; the legacy globals are untouched from the
+/// caller's point of view (saved, applied for the load, restored). A
+/// concurrent plain baseRT_load_model on another thread races the applied
+/// values exactly as it would race the legacy setters — serialize loads if
+/// you mix the two forms.
+baseRT_model_t baseRT_load_model_ex(const char *model_path, const char *kernel_library_path, int max_context,
+                                    const BaseRTLoadOptions *opts);
+
+/// Capability flags reported by baseRT_capabilities(). A scheduler should
+/// branch on these instead of probing entry points for BASERT_ERR_UNSUPPORTED
+/// or inferring support from BaseRTModelConfig fields.
+enum {
+    BASERT_CAP_PAGED_KV = 1u << 0,      ///< loaded with paged KV (sequences, prefix seeding)
+    BASERT_CAP_SEQUENCES = 1u << 1,     ///< baseRT_sequence_create works: continuous batching
+    BASERT_CAP_HOST_LOGITS = 1u << 2,   ///< baseRT_batch_step_fused_logits + read_batch_logits work
+    BASERT_CAP_PREFIX_CACHE = 1u << 3,  ///< RadixCache prefix reuse is active
+    BASERT_CAP_GDN_SNAPSHOT = 1u << 4,  ///< hybrid-GDN recurrent-state snapshot/restore
+};
+
+/// What this loaded model supports, as BASERT_CAP_* flags. Pure query: no GPU
+/// work, no probe sequences, never touches the error state. Values are fixed
+/// at load time. When a capability is absent and the reason matters (e.g. an
+/// operator-facing "continuous batching disabled because ..." message), call
+/// the gated entry point once and read baseRT_get_error().
+uint32_t baseRT_capabilities(baseRT_model_t model);
+
 /// Override the KV cache element width for the next baseRT_load_model call.
 ///   bits = 0  → auto (per-model default; Q8_0 when head_dim%32==0)
 ///   bits = 8  → force Q8_0 K and V slabs (1.88x smaller; tiny precision cost)
@@ -103,7 +134,7 @@ void baseRT_set_kv_bits(int bits);
 
 /// Enable engine diagnostics (RoPE/tokenizer/GPU/architecture dumps, the
 /// per-token dispatch-command count, "Warming up"). Off by default so end
-/// users see only model output. Also honored via the BASERT_VERBOSE env var.
+/// users see only model output.
 void baseRT_set_verbose(int on);
 
 /// Toggle paged-KV mode for the next baseRT_load_model call.
@@ -153,6 +184,23 @@ void baseRT_set_paged_weights(int mode);
 /// Process-wide; read per decode step.
 void baseRT_set_baked_decode(int enable);
 
+/// CUDA decode-replay strategy for fused batch decode ticks.
+///   mode = 2 → stream capture (default): capture the live walk as a CUDA
+///     graph on a shape's second sighting; replay is numerically identical
+///     to the live tick it captured.
+///   mode = 1 → cmd-table replay (experiment; measured a net loss on GB10
+///     serving — see batch_step_fused_common).
+///   mode = 0 → neither: fused ticks run live (no capture, no cmd-table
+///     replay).
+/// Governs ONLY the CUDA fused-tick replay strategy. The baked DispatchTable
+/// fast path for pure-decode ticks is a separate mechanism with its own
+/// switch — baseRT_set_baked_decode(0) — matching the two knobs' historical
+/// independence. Process-wide; the fused decode paths latch the mode on
+/// first use, so set it before the first decode step. Other values are
+/// ignored. No effect on the Metal backend. (Replaces the
+/// BASERT_FUSED_BUCKETS / BASERT_STREAM_CAPTURE env gates.)
+void baseRT_set_decode_replay(int mode);
+
 /// GPU-wait timeout in milliseconds (Metal backend).
 ///   ms > 0   → (default: 300000, i.e. 5 min) return a loggable error if a
 ///     committed command buffer doesn't reach a terminal status in time. The
@@ -160,8 +208,7 @@ void baseRT_set_baked_decode(int enable);
 ///     reset/reboot reclaims it). Chosen far above any legitimate single
 ///     command buffer so only a real wedge trips it.
 ///   ms = 0   → block indefinitely in the GPU wait (opt out of the bound).
-/// No-op on non-Metal backends. Process-wide; read once per wait. The initial
-/// value also honors the BASERT_GPU_WAIT_TIMEOUT_MS environment variable.
+/// No-op on non-Metal backends. Process-wide; read once per wait.
 void baseRT_set_gpu_wait_timeout_ms(double ms);
 
 /// Free all resources associated with a model.
@@ -291,26 +338,9 @@ BaseRTGenerationStats baseRT_sequence_generate_continue(baseRT_sequence_t seq, c
 /// Release the sequence's blocks back to the pool and free the handle.
 void baseRT_sequence_free(baseRT_sequence_t seq);
 
-/// Fused batch step with per-sequence trailing PAD counts (serving grid
-/// alignment): counts[i] includes pads[i] throwaway tokens whose rows are
-/// computed but whose argmax row is skipped (the output token comes from the
-/// last REAL row). The caller must roll each padded sequence's KV back by
-/// pads[i] after the call (baseRT_sequence_rollback). Greedy only.
-int baseRT_batch_step_fused_pads(baseRT_model_t model, baseRT_sequence_t *seqs, int n_seqs, const uint32_t *in_tokens,
-                                 const int *in_token_counts, const int *pads, uint32_t *out_tokens);
-
-/// Warm the batched-decode fast paths for batch sizes up to `max_batch`:
-/// each B runs two throwaway pure-decode ticks so shape-keyed caches (baked
-/// dispatch tables, stream-captured CUDA graphs, cuBLAS plans) are built at
-/// startup instead of on the first real requests — the same boot-time graph
-/// warmup vLLM performs. Requires --paged-kv; call after load, before serving.
-int baseRT_batch_warmup(baseRT_model_t model, int max_batch);
-
-/// Roll a sequence's KV state back to `length` tokens, returning any blocks
-/// past that point to the pool. `length` must be <= the current length; 0
-/// resets the sequence to empty. Used by the serving engine's shape-padding
-/// dummy lanes (their KV is discarded after every tick).
-int baseRT_sequence_rollback(baseRT_sequence_t seq, int length);
+// baseRT_batch_step_fused_pads / baseRT_batch_warmup /
+// baseRT_sequence_rollback are declared once, below with the rest of the
+// batched-decode API (their doc blocks had already started drifting apart).
 
 /// Batched decode: drives ONE batched decode step across N sequences. Each
 /// sequence writes its `new_tokens[i]` to its own KV cache slot, and attention
@@ -469,6 +499,55 @@ int baseRT_batch_step_fused_logits(baseRT_model_t model, baseRT_sequence_t *seqs
 /// `n_seqs` must match the batch of the preceding step and be <= max_batch_size.
 int baseRT_read_batch_logits(baseRT_model_t model, int n_seqs, void *out_logits_f16);
 
+// === Host-side logits-row operations ===
+//
+// Companions to baseRT_read_batch_logits for schedulers that sample on the
+// host: they encapsulate the engine's logits element type and row layout so
+// the caller never casts raw buffers or re-implements dtype-sensitive math
+// (which must stay bit-compatible with the engine's own greedy/sampled paths).
+// A "row" below is one sequence's logits inside the buffer written by
+// baseRT_read_batch_logits: row `s` starts at byte offset
+// `s * baseRT_batch_logits_stride(model)`.
+
+/// Bytes between consecutive sequence rows in the baseRT_read_batch_logits
+/// output buffer (also the size of one row). Size the readback buffer as
+/// `n_seqs * stride` bytes. Returns 0 on a null model.
+size_t baseRT_batch_logits_stride(baseRT_model_t model);
+
+/// Apply a grammar bitmask (from baseRT_grammar_fill_bitmask; a SET bit =
+/// allowed token) to one logits row IN PLACE: every disallowed token's logit
+/// becomes -inf, so subsequent sampling and logprob reads on the row see the
+/// constrained distribution. Returns BASERT_OK or an error code.
+int baseRT_mask_logits_row(baseRT_model_t model, void *row, const int32_t *bitmask);
+
+/// Run the full CPU sampling pipeline (temperature / top-k / top-p / min-p /
+/// repetition + presence + frequency penalties / logit_bias) over one logits
+/// row. `prev_tokens`/`n_prev` feed the repetition penalties;
+/// `repeat_window` bounds how many trailing prev_tokens are penalized (0 =
+/// all). When cfg->seed != 0 the sampling RNG is reseeded with
+/// cfg->seed + seed_offset first — pass the per-sequence generated-token
+/// count as seed_offset for deterministic per-lane streams under batch
+/// interleaving. Returns the sampled token id (0 with the error state set on
+/// invalid arguments).
+uint32_t baseRT_sample_logits_row(baseRT_model_t model, const void *row, const BaseRTSamplingConfig *cfg,
+                                  const uint32_t *prev_tokens, int n_prev, int repeat_window, uint32_t seed_offset);
+
+/// Lowest-index argmax over one logits row — the exact tie-break of the GPU
+/// argmax and the CPU greedy fast path, which sampling with top_k=1 does NOT
+/// guarantee (equal-logit ties are common with f16 logits). Use this for
+/// greedy lanes in a host-sampled batch. Returns 0 with the error state set
+/// on invalid arguments.
+uint32_t baseRT_argmax_logits_row(baseRT_model_t model, const void *row);
+
+/// Log-softmax over one logits row: writes the chosen token's logprob to
+/// *out_token_logprob and the top `top_k` alternatives (ids + logprobs,
+/// descending) to out_ids/out_logprobs, which must hold top_k entries.
+/// top_k = 0 computes only the chosen token's logprob. Returns the number of
+/// alternatives written, or < 0 with the error state set on invalid
+/// arguments.
+int baseRT_logits_row_logprobs(baseRT_model_t model, const void *row, uint32_t token, int top_k,
+                               float *out_token_logprob, uint32_t *out_ids, float *out_logprobs);
+
 // === Prefix cache — scheduler-driven primitives ===
 //
 // A scheduler (e.g. the continuous-batching BatchEngine) reuses the KV of a
@@ -507,8 +586,11 @@ BaseRTPrefixMatch baseRT_prefix_match(baseRT_model_t model, const uint32_t *toke
 
 /// Seed a freshly-created, empty sequence with the shared blocks from a match
 /// so it reuses their KV instead of re-prefilling. `n_tokens` must equal
-/// `n_blocks * page_size`. Returns BASERT_OK, or an error if the model isn't
-/// paged / the sequence isn't empty.
+/// `n_blocks * page_size`. An empty match (n_blocks == 0 && n_tokens == 0) is
+/// a successful no-op; any other zero/null combination is rejected with
+/// BASERT_ERR_INVALID_ARGUMENT (nothing was adopted — release the match).
+/// Returns BASERT_OK, or an error if the model isn't paged / the sequence
+/// isn't empty.
 int baseRT_sequence_seed_prefix(baseRT_sequence_t seq, const int *blocks, int n_blocks, int n_tokens);
 
 /// Paged-KV block (page) size in tokens for this model, or 0 when the model
@@ -634,7 +716,8 @@ BaseRTGenerationStats baseRT_generate_grammar_continue(baseRT_model_t model, con
 /// Runs each layer in its own command buffer for accurate GPU timing.
 /// Much slower than normal decode — use only for profiling.
 /// timing_out: array of (n_layers + 3) floats [embedding, norm, layer0..N-1, logit, argmax]
-/// Returns number of timing entries written.
+/// Returns number of timing entries written, or -1 on a failed step
+/// (details via baseRT_get_error).
 int baseRT_profile_decode_step(baseRT_model_t model, uint32_t token_id, int position, float *timing_out,
                                int max_entries);
 
@@ -936,10 +1019,7 @@ const char *baseRT_eos_token(baseRT_model_t model);
 /// other token-id consumers stop on). Returns 0 on a null handle.
 uint32_t baseRT_eos_token_id(baseRT_model_t model);
 
-/// Max prompt tokens the fused (varlen) prefill can process in one packed batch.
-/// The continuous-batching engine caps per-tick admitted prompt tokens by this
-/// so a burst of long prompts doesn't overflow the packed prefill. 0 on null.
-int baseRT_max_prefill_chunk(baseRT_model_t model);
+// (baseRT_max_prefill_chunk is declared once, with the batched-decode API.)
 
 // === Token counting ===
 
@@ -981,6 +1061,54 @@ const char *baseRT_transcribe_stream(baseRT_model_t model, const char *wav_path,
 /// When enabled (default): produces [start --> end] text segments with seeking.
 /// When disabled: faster greedy decode, plain text output.
 void baseRT_set_timestamps(baseRT_model_t model, bool enabled);
+
+/// Set the Whisper task: "transcribe" (default) or "translate" (any-to-English).
+/// NULL resets to "transcribe". Returns false (with baseRT_get_error set) on an
+/// unknown task string, or on "translate" with an English-only model.
+bool baseRT_set_task(baseRT_model_t model, const char *task);
+
+/// Set an initial prompt for Whisper transcription (reference `initial_prompt`):
+/// tokenized and fed after <|startofprev|> ahead of the first window's prompt,
+/// biasing the decode (names, spellings, style). NULL or "" clears it.
+/// On models whose tokenizer cannot encode text (legacy GGML whisper files
+/// without BPE merges) the prompt is ignored with a warning at transcribe time.
+void baseRT_set_initial_prompt(baseRT_model_t model, const char *text);
+
+/// condition_on_previous_text (default true, reference semantics): feed each
+/// window the previous windows' decoded text after <|startofprev|>. Disable if
+/// the model gets stuck in repetition loops on your audio.
+void baseRT_set_condition_on_previous_text(baseRT_model_t model, bool enabled);
+
+/// Language code of the LAST transcription: the detected code when the request
+/// language was NULL/""/"auto", otherwise the requested code. Empty string if
+/// no transcription has run. Valid until the next transcription or model free.
+const char *baseRT_transcribe_language(baseRT_model_t model);
+
+/// Duration of the LAST transcription's source audio, in milliseconds
+/// (n_samples at 16 kHz — the OpenAI verbose_json `duration` field is this
+/// value in fractional seconds). 0 if no transcription has run.
+int baseRT_transcribe_audio_duration_ms(baseRT_model_t model);
+
+/// Per-segment metadata for the LAST transcription (verbose_json surface).
+/// avg_logprob / no_speech_prob / compression_ratio / temperature are
+/// window-level values applied to every segment decoded in that 30 s window
+/// (the reference computes them per-decode-result; window-level is this
+/// engine's documented approximation for chain-decoded tokens).
+typedef struct {
+    int start_ms;
+    int end_ms;
+    const char *text;  // valid until the next transcription or model free
+    float avg_logprob;
+    float no_speech_prob;
+    float compression_ratio;
+    float temperature;
+} BaseRTTranscribeSegment;
+
+/// Number of segments produced by the last transcription (0 if none).
+int baseRT_transcribe_segment_count(baseRT_model_t model);
+
+/// Fetch one segment of the last transcription. Returns false on bad index.
+bool baseRT_transcribe_segment(baseRT_model_t model, int index, BaseRTTranscribeSegment *out);
 
 /// Check if loaded model is a Whisper model.
 bool baseRT_is_whisper(baseRT_model_t model);

--- a/include/baseRT/types.h
+++ b/include/baseRT/types.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <stddef.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -240,6 +241,23 @@ typedef struct {
     float prefill_tokens_per_sec;
     float decode_tokens_per_sec;
 } BaseRTGenerationStats;
+
+/// Per-load configuration for baseRT_load_model_ex. Replaces the process-wide
+/// baseRT_set_* pre-load setters with values scoped to one load call, so a
+/// lazily-reloading host (e.g. a server's model registry) doesn't depend on
+/// globals set once at startup. Zero-initialize (`BaseRTLoadOptions opts = {0}`
+/// / value-init) and set `struct_size = sizeof(BaseRTLoadOptions)`; every
+/// zero field keeps today's default, so a zeroed struct behaves exactly like
+/// plain baseRT_load_model with no setters called.
+typedef struct {
+    size_t struct_size;      ///< must be sizeof(BaseRTLoadOptions); ABI guard
+    int kv_bits;             ///< 0 default, or 4 / 8 / 16 / 84 (84 = K@Q8, V@Q4)
+    int paged_kv;            ///< 0 default (off), 1 on
+    int max_batch_size;      ///< 0 default (1), else >= 1 decode lanes
+    int prefix_cache;        ///< 0 default (off), 1 on (needs paged_kv)
+    int prefill_chunk;       ///< 0 per-chip default, else tokens per prefill pass
+    int paged_weights_mode;  ///< 0 auto-retry on GPU-OOM, 1 force paged, 2 fail hard
+} BaseRTLoadOptions;
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Brings the public C API and all four bindings up to the engine the `v0.2.1` tag will ship — the same ordering the 0.1.7 and 0.2.0 syncs used, so the published source matches the released binary rather than trailing it.

Generated by the internal `tools/sync_public.py` allow-list, then scoped to headers and bindings (the converter half is #40).

## New public surface

- **Whisper transcription** — task selection, initial prompt, condition-on-previous-text, per-segment results, detected language, source-audio duration.
- **`baseRT_load_model_ex` + `BaseRTLoadOptions`** — per-load KV width, paged-KV, batch size, prefix cache, prefill chunk and paged-weight mode, replacing the process-wide setters. ABI-guarded by `struct_size`.
- **Batched logits** — `baseRT_batch_logits_stride`, `baseRT_argmax_logits_row`, `baseRT_sample_logits_row`, `baseRT_logits_row_logprobs`, `baseRT_mask_logits_row`.
- **`baseRT_capabilities`**.

Version stamps move to 0.2.1 across the header macros and the Python, Node and Rust manifests.

## One thing to be aware of when merging

Until the 0.2.1 binary is published, this source describes entry points the released **0.2.0** engine does not export. I checked the one job that could trip on that: `rust-sys ABI checks` downloads the latest release and runs `cargo test` against it, but the tests covering the new types only assert **struct layout** (`BaseRTTranscribeStats` size/alignment/defaults) rather than calling the new functions — and Rust only emits undefined references for functions actually called, so it stays green.

Still, this should land close to the tag rather than long before it: anyone building bindings from `main` against an installed 0.2.0 engine would find the new calls missing at run time.

Depends on nothing in #40; the two are disjoint (converter vs. headers/bindings) and can merge in either order.